### PR TITLE
Add comprehensive module and file documentation

### DIFF
--- a/docs/poisson_3d_fft/doc_build_kernel.f90.md
+++ b/docs/poisson_3d_fft/doc_build_kernel.f90.md
@@ -1,0 +1,135 @@
+# `build_kernel.f90`
+
+## Overview
+
+The `build_kernel.f90` file is a crucial part of the `Poisson_Solver` module within the `poisson_3d_fft` package. It is not a standalone Fortran module but a collection of subroutines intended to be directly `include`d into the main `Poisson_Solver` module file (`poisson_solver.f90`). Its primary responsibility is to construct the Green's function (often referred to as the Poisson kernel) in reciprocal (Fourier) space, denoted as $G(k)$. This kernel is essential for solving Poisson's equation $\nabla^2 V = -4\pi\rho$ via FFT methods, where the solution in Fourier space is $V(k) = G(k) \rho(k)$.
+
+The specific form of $G(k)$ and the method of its construction depend significantly on the boundary conditions of the problem ('F' for Free, 'S' for Surface, 'P' for Periodic) and, for non-periodic cases, on the type of interpolating scaling functions used to represent the Green's function.
+
+## Key Components
+
+### File Type
+A collection of Fortran subroutines, designed for direct inclusion into `poisson_solver.f90`.
+
+### Main Public-Facing Subroutine (Exposed via `Poisson_Solver`)
+
+-   **`createKernel(geocode, n01, n02, n03, hx, hy, hz, itype_scf, iproc, nproc, kernel)`**:
+    -   **Description:** This is the primary routine made available through the `Poisson_Solver` module that originates from this file. It acts as a dispatcher based on the `geocode` argument:
+        -   If `geocode = 'P'` (Periodic): The kernel is simple ($1/k^2$, often handled directly in the solver), so this routine may only allocate a minimal placeholder for `kernel` or perform basic setup. The actual $1/k^2$ scaling is applied in `P_PoissonSolver`.
+        -   If `geocode = 'S'` (Surface): It calls `S_FFT_dimensions` (from `psolver_main.f90`) to determine appropriate FFT grid dimensions and then invokes the `Surfaces_Kernel` subroutine to compute the specific kernel $G(k)$ for surface boundary conditions.
+        -   If `geocode = 'F'` (Free): It calls `F_FFT_dimensions` (from `psolver_main.f90`) and then invokes the `Free_Kernel` subroutine to compute $G(k)$ for free-space (isolated system) boundary conditions.
+    -   **Output:** The `kernel` argument, a pointer, is allocated and filled with the computed reciprocal space Green's function values. For parallel runs (`nproc > 1`), this kernel data is typically distributed across processes.
+    -   **Arguments:**
+        -   `geocode (character(len=1), intent(in))`: Specifies boundary conditions ('P', 'S', 'F').
+        -   `n01, n02, n03 (integer, intent(in))`: Dimensions of the real-space grid.
+        -   `hx, hy, hz (real(kind=8), intent(in))`: Grid spacings.
+        -   `itype_scf (integer, intent(in))`: Order of interpolating scaling functions used for kernel construction in non-periodic cases.
+        -   `iproc, nproc (integer, intent(in))`: MPI rank of the current process and total number of processes.
+        -   `kernel (real(kind=8), pointer, intent(out))`: On exit, points to the allocated array containing the computed kernel $G(k)$.
+
+### Core Kernel Construction Subroutines (Internal to `build_kernel.f90`)
+
+-   **`Surfaces_Kernel(n1, n2, n3, m3, nker1, nker2, nker3, h1, h2, h3, itype_scf, karray, iproc, nproc)`**:
+    -   **Description:** Computes the Poisson kernel for surface boundary conditions (periodic in xz, isolated in y, where y is the third dimension `n3`/`m3` due to internal dimension swapping). This involves:
+        1.  Generating 1D Green's function components in the non-periodic direction using interpolating scaling functions (via `calculates_green_opt_muzero` for $k_{y_p}=0$ and `calculates_green_opt` for $k_{y_p} \neq 0$, where $k_{y_p}$ is the wavevector component in the periodic plane). These helpers utilize `scaling_function` (from `scaling_function.f90`) and numerical integration with pre-defined polynomial coefficients (`cpol`).
+        2.  Performing a "half-FFT" like procedure along the non-periodic dimension for each $(k_x, k_z)$ pair.
+        3.  Distributing the final `karray` among MPI processes using `MPI_ALLTOALL`.
+    -   **Key Techniques:** Use of scaling functions, specialized Green's function calculations for $k_p=0$ and $k_p \neq 0$, custom FFT-like processing for the mixed boundary condition.
+
+-   **`Free_Kernel(n01, n02, n03, nfft1, nfft2, nfft3, n1k, n2k, n3k, hx, hy, hz, itype_scf, iproc, nproc, karray)`**:
+    -   **Description:** Computes the Poisson kernel for free boundary conditions (isolated system). This is typically more complex than the periodic case. The method involves:
+        1.  Representing the $1/r$ interaction using a sum of Gaussian functions via Gaussian quadrature (`gequad` provides abscissas `p_gauss` and weights `w_gauss`).
+        2.  For each Gaussian, constructing its representation using interpolating scaling functions (via `scaling_function` and `scf_recursion` from `scaling_function.f90`). This effectively creates a real-space representation of the kernel (`kp`).
+        3.  Transforming this real-space kernel `kp` to reciprocal space `karray` using a 3D FFT via the `kernelfft` subroutine.
+    -   **Key Techniques:** Gaussian quadrature for $1/r$, representation with scaling functions, 3D FFT of the constructed real-space kernel.
+
+### Helper Subroutines (Selected)
+
+-   **`calculates_green_opt(...)`, `calculates_green_opt_muzero(...)`**: Used by `Surfaces_Kernel` to compute 1D Green's functions for the non-periodic direction using scaling functions and handling the $k_p=0$ (muzero) case separately.
+-   **`gequad(nterms, p, w, urange, drange, acc)`**: Provides `nterms` abscissas (`p`) and weights (`w`) for Gaussian quadrature. Data for 89 points is hardcoded. Used in `Free_Kernel`.
+-   **`kernelfft(n1,n2,n3,nd1,nd2,nd3,nk1,nk2,nk3,nproc,iproc,zf,zr)`**: Performs a 3D FFT. Takes a real-space kernel `zf` (e.g., `kp` from `Free_Kernel`) and computes its complex reciprocal-space counterpart `zr` (which becomes `karray`). It manages data distribution for MPI and calls 1D FFT routines (`fftstp` from `fft3d.f90`).
+-   **`indices(...)`**: A small utility for calculating array indices, used within `Surfaces_Kernel`.
+-   **`inserthalf(...)`, `realcopy(...)`, `switch(...)`, `mpiswitch(...)`**: Data manipulation routines used by `kernelfft` to arrange data for 1D FFT passes or MPI communication.
+
+## Important Variables/Constants
+
+-   **`n_points (integer, parameter)`**: Within `Surfaces_Kernel` and `Free_Kernel`, number of points for fine-grained integration related to scaling functions (value: $2^6=64$).
+-   **`n_gauss (integer, parameter)`**: In `Free_Kernel`, the number of Gaussian functions used to represent $1/r$ (value: 89).
+-   **`p_gauss, w_gauss (real(kind=8), dimension(n_gauss))`**: In `Free_Kernel`, arrays storing the exponents and weights for the Gaussian expansion of $1/r$, initialized by `gequad`.
+-   **`cpol (real(kind=8), dimension(9,8))`**: In `Surfaces_Kernel`, hardcoded coefficients for polynomial interpolation used in the Green's function calculation helpers.
+-   **`iproc_verbose (integer)`**: Module variable from `Poisson_Solver` used here to control print statements.
+
+## Dependencies and Interactions
+
+-   **Internal Dependencies (within `poisson_3d_fft` directory):**
+    -   Relies on dimension calculation routines like `F_FFT_dimensions` and `S_FFT_dimensions` (defined in `psolver_main.f90` but available via include).
+    -   `Surfaces_Kernel` and `Free_Kernel` depend on `scaling_function` and associated routines (like `scf_recursion_XX`) from `scaling_function.f90` for constructing parts of the Green's function.
+    -   `Free_Kernel` (via `kernelfft`) and `Surfaces_Kernel` (for its "half-FFT") depend on the 1D FFT routines `fftstp` and `ctrig` from `fft3d.f90`.
+-   **External Libraries:**
+    -   **MPI:** The `MPI_ALLTOALL` routine is used in `Surfaces_Kernel` and `kernelfft` for distributing the computed kernel data among processes. `MPI_COMM_WORLD` is used.
+-   **Interactions with Other Components:**
+    -   The main entry point `createKernel` is called by the `Poisson_Solver` module (specifically, it's a public routine of `Poisson_Solver` whose implementation is in this file).
+    -   The output `kernel` (pointer to `karray`) from `createKernel` is a critical input to the main `PSolver` subroutine (defined in `psolver_main.f90` and implemented in `psolver_base.f90`). `PSolver` uses this kernel to multiply the FFT of the density in reciprocal space.
+
+## Usage Examples
+
+The `createKernel` subroutine is typically not called directly by an end-user of the `m_octree_mg` library, but rather internally by `m_free_space` when it initializes the `Poisson_Solver`. However, a conceptual call would look like this:
+
+```fortran
+! Conceptual Example: How createKernel is invoked.
+
+module ExampleKernelCreation
+  use Poisson_Solver ! This makes createKernel (and its dependencies) available
+  use mpi            ! MPI environment is needed by createKernel and its helpers
+  implicit none
+
+  subroutine generate_poisson_kernel()
+    real(kind=8), pointer :: my_kernel_array(:)
+    real(kind=8) :: hx, hy, hz       ! Grid spacings
+    integer    :: nx, ny, nz       ! Grid dimensions
+    integer    :: mpi_current_rank, num_mpi_tasks
+    integer    :: scaling_func_order, mpi_error_code
+    character(len=1) :: boundary_type_code
+
+    ! Initialize MPI (usually done at a higher level)
+    call MPI_Comm_rank(MPI_COMM_WORLD, mpi_current_rank, mpi_error_code)
+    call MPI_Comm_size(MPI_COMM_WORLD, num_mpi_tasks, mpi_error_code)
+
+    ! Define problem parameters
+    nx = 128; ny = 128; nz = 128
+    hx = 0.1d0; hy = 0.1d0; hz = 0.1d0
+    boundary_type_code = 'F'  ! Free-space boundary conditions
+    scaling_func_order = 16   ! Order of interpolating scaling functions
+
+    ! Call createKernel to compute and allocate the kernel
+    call createKernel(geocode=boundary_type_code, &
+                      n01=nx, n02=ny, n03=nz, &
+                      hx=hx, hy=hy, hz=hz, &
+                      itype_scf=scaling_func_order, &
+                      iproc=mpi_current_rank, nproc=num_mpi_tasks, &
+                      kernel=my_kernel_array)
+
+    ! my_kernel_array is now allocated and contains the computed kernel in reciprocal space,
+    ! distributed among MPI processes if num_mpi_tasks > 1.
+    ! This kernel can then be passed to the PSolver routine.
+
+    ! ... (Further operations, e.g., calling PSolver) ...
+
+    ! Deallocate the kernel when it's no longer needed
+    if (associated(my_kernel_array)) then
+      deallocate(my_kernel_array)
+    end if
+
+  end subroutine generate_poisson_kernel
+end module ExampleKernelCreation
+
+program TestDriver
+  use ExampleKernelCreation
+  use mpi
+  implicit none
+  integer :: ierr
+  call MPI_Init(ierr)
+  call generate_poisson_kernel()
+  call MPI_Finalize(ierr)
+end program TestDriver
+```

--- a/docs/poisson_3d_fft/doc_fft3d.f90.md
+++ b/docs/poisson_3d_fft/doc_fft3d.f90.md
@@ -1,0 +1,127 @@
+# `fft3d.f90`
+
+## Overview
+
+The file `fft3d.f90` is a collection of low-level Fortran subroutines that provide the core Fast Fourier Transform (FFT) capabilities used within the `Poisson_Solver` module of the `poisson_3d_fft` package. This file does not define a self-contained Fortran `module` in the typical sense; rather, its subroutines are designed to be directly `include`d into other source files where FFT functionality is required (e.g., `psolver_base.f90`, `build_kernel.f90`).
+
+The routines handle critical aspects of the FFT process:
+1.  Determining optimal grid dimensions that are efficient for FFT algorithms (products of small prime factors).
+2.  Pre-calculating the trigonometric coefficients (twiddle factors) needed for the FFT stages.
+3.  Executing the individual 1D complex-to-complex FFT steps (passes) that form the basis of multi-dimensional FFTs.
+
+This appears to be a custom implementation of the Cooley-Tukey FFT algorithm, or a similar radix-based approach, rather than a wrapper around a standard library like FFTW.
+
+## Key Components
+
+### File Type
+A collection of Fortran subroutines, intended for direct inclusion. No `module` statement is present in this file.
+
+### Key Subroutines (Effectively Public via `include`)
+
+-   **`fourier_dim(n, n_next)`**:
+    -   **Description:** Given an input integer `n`, this subroutine finds and returns in `n_next` the smallest integer greater than or equal to `n` that is suitable for efficient FFT computation. It uses a hardcoded list (`idata`) of integers that are products of small prime factors (2, 3, 5), which are known to be efficient lengths for FFT algorithms.
+    -   **Arguments:**
+        -   `n (integer, intent(in))`: The desired minimum dimension.
+        -   `n_next (integer, intent(out))`: The returned FFT-friendly dimension.
+
+-   **`ctrig(n, trig, after, before, now, isign, ic)`**:
+    -   **Description:** This subroutine prepares the necessary trigonometric coefficients (twiddle factors, which are complex exponentials $e^{\pm 2\pi i k/N}$) for performing an FFT of length `n`. It also determines the factorization of `n` into stages suitable for the Cooley-Tukey algorithm. The factorization information (radices for each stage, number of transforms at each stage, etc.) is stored in the `after`, `before`, and `now` arrays, with `ic` being the number of stages. The `isign` argument (+1 or -1) determines the sign in the exponent, allowing for both forward and inverse transforms. The pre-calculated sine and cosine values are stored in the `trig` array.
+    -   **Arguments:**
+        -   `n (integer)`: The length of the 1D transform.
+        -   `trig (real(kind=8), dimension(2,nfft_max))`: Output array storing the real and imaginary parts of the twiddle factors.
+        -   `after(7), before(7), now(7) (integer)`: Output arrays describing the factorization of `n` for the FFT stages.
+        -   `isign (integer)`: Sign for the exponent in twiddle factors (e.g., -1 for forward, +1 for inverse, or vice-versa depending on convention).
+        -   `ic (integer)`: Output, the number of FFT stages.
+
+-   **`fftstp(mm, nfft, m, nn, n, zin, zout, trig, after, now, before, isign)`**:
+    -   **Description:** This subroutine performs a single "step" or "pass" of a 1D complex-to-complex FFT. It processes `nfft` transforms simultaneously. The `now` argument (from `ctrig`) specifies the radix of the current FFT stage (e.g., 2, 3, 4, 5, 6, 8). The routine uses the pre-calculated twiddle factors from `trig` and the stage information (`after`, `before`) to combine input data from `zin` and store the result in `zout`. This routine is called multiple times (once for each stage `ic` determined by `ctrig`) to complete a full 1D FFT. The `isign` parameter ensures the correct twiddle factors are used for either a forward or an inverse transform.
+    -   **Arguments:**
+        -   `mm, nfft, m, nn, n (integer)`: Parameters related to data layout, number of transforms, and dimensions for efficient processing (often related to cache blocking).
+        -   `zin (real(kind=8), dimension(2,mm,m))`: Input complex data (real and imaginary parts).
+        -   `zout (real(kind=8), dimension(2,nn,n))`: Output complex data.
+        -   `trig (real(kind=8), dimension(2,nfft_max))`: Pre-calculated twiddle factors from `ctrig`.
+        -   `after, now, before (integer)`: Current FFT stage parameters from `ctrig`.
+        -   `isign (integer)`: Sign for the transform direction.
+
+## Important Variables/Constants
+
+-   **`nfft_max (integer, parameter)`**: Defined in `ctrig` and `fftstp` (value 24000). This limits the maximum length of a 1D FFT for which twiddle factors can be pre-stored in the `trig` array.
+-   **`idata (integer, dimension(ndata), parameter)`**: In `fourier_dim`, a hardcoded list of 180 integers that are products of small primes (2, 3, 5), suitable for FFTs. The largest is 24000.
+-   **`idata (integer, dimension(7,ndata), parameter)`**: In `ctrig`, a hardcoded table providing factorizations for the integers listed in `fourier_dim`'s `idata`. These factorizations (into factors of 2, 3, 4, 5, 6, 8) determine the stages of the `fftstp` routine.
+-   **Numerical Constants:** `rt2i = sqrt(0.5d0)` (i.e., $1/\sqrt{2}$), `cos2/sin2` (for $\cos(2\pi/5), \sin(2\pi/5)$), `cos4/sin4` (for $\cos(4\pi/5), \sin(4\pi/5)$), `bb` (for $\sin(2\pi/3)$ or $\cos(\pi/6)$ related to factor-3 FFTs) are used in `fftstp` for specific radices.
+
+## Dependencies and Interactions
+
+-   **Internal Dependencies:**
+    -   `fftstp` relies on the setup performed by `ctrig` (factorization of N and twiddle factors).
+-   **External Libraries:**
+    -   None. The FFT implementation appears to be entirely self-contained within this file and the routines that call it. It does not seem to wrap standard FFT libraries like FFTW.
+-   **Interactions with Other Components (within `poisson_3d_fft`):**
+    -   **`psolver_base.f90` (e.g., `P_PoissonSolver`, `S_PoissonSolver`, `F_PoissonSolver`) and `build_kernel.f90` (e.g., `kernelfft`):** These higher-level routines are the primary callers of `ctrig` and `fftstp`. They orchestrate the full 3D FFT by:
+        1.  Calling `ctrig` to prepare for 1D transforms along each dimension.
+        2.  Calling `fftstp` multiple times for each dimension to perform the 1D FFTs. This often involves data reordering or transposition steps (handled within `psolver_base.f90` or `kernelfft.f90` through helper routines like `switch`, `mpiswitch`, `scramble_unpack`, etc.) to present data to `fftstp` as contiguous 1D arrays or slices.
+    -   **`psolver_main.f90` (via `P/S/F_FFT_dimensions`):** Uses `fourier_dim` to ensure that the grid dimensions chosen for the Poisson solve are efficient for the FFT routines provided in this file.
+
+## Usage Examples
+
+The subroutines in `fft3d.f90` are low-level components of the 3D FFT algorithm within the `Poisson_Solver` module. A typical end-user of the `Poisson_Solver` (or the `m_octree_mg` library) would not call these routines directly. They are used internally by routines like `P_PoissonSolver`, `S_PoissonSolver`, `F_PoissonSolver`, and `kernelfft`.
+
+**Conceptual Invocation for a 1D FFT (as used by higher-level 3D FFT routines):**
+
+```fortran
+! Conceptual example of how a higher-level routine might use ctrig and fftstp
+! to perform a 1D FFT on multiple data vectors.
+
+implicit none
+real(kind=8) :: my_data_array(2, 128, 10) ! Example: 10 complex vectors, each of length 128
+real(kind=8) :: work_array(2, 128, 10)    ! Work array for ping-ponging
+real(kind=8) :: twiddle_factors(2, 24000) ! Max size from nfft_max
+integer :: factors_after(7), factors_now(7), factors_before(7)
+integer :: num_fft_stages, current_stage
+integer :: N_length, num_vectors
+integer :: isign_direction
+
+N_length = 128
+num_vectors = 10 ! This would be 'nfft' in fftstp if processing all vectors in one call
+isign_direction = -1 ! For a forward FFT (convention-dependent)
+
+! 1. Pre-calculate twiddle factors and FFT stages for length N_length
+call ctrig(N_length, twiddle_factors, factors_after, factors_before, &
+           factors_now, isign_direction, num_fft_stages)
+
+! 2. Perform the FFT using fftstp for each stage
+!    Source and destination arrays might ping-pong between my_data_array and work_array.
+!    For simplicity, assume source is my_data_array, destination is work_array for 1st stage.
+
+! Loop over each stage of the FFT
+do current_stage = 1, num_fft_stages
+  if (mod(current_stage, 2) == 1) then ! Odd stages: my_data_array -> work_array
+    call fftstp(N_length, num_vectors, factors_now(current_stage), & ! mm, nfft, m (radix)
+                N_length, num_vectors,                               & ! nn, n
+                my_data_array, work_array,                            & ! zin, zout
+                twiddle_factors,                                      & ! trig
+                factors_after(current_stage), factors_now(current_stage), &
+                factors_before(current_stage), isign_direction)
+  else ! Even stages: work_array -> my_data_array
+    call fftstp(N_length, num_vectors, factors_now(current_stage), &
+                N_length, num_vectors,                               &
+                work_array, my_data_array,                            &
+                twiddle_factors,                                      &
+                factors_after(current_stage), factors_now(current_stage), &
+                factors_before(current_stage), isign_direction)
+  end if
+end do
+
+! Final result is in my_data_array if num_fft_stages is even,
+! or in work_array if num_fft_stages is odd. A final copy might be needed.
+
+! To find an FFT-friendly dimension:
+integer :: my_dim, good_fft_dim
+my_dim = 120
+call fourier_dim(my_dim, good_fft_dim)
+! good_fft_dim will be 120
+
+my_dim = 121
+call fourier_dim(my_dim, good_fft_dim)
+! good_fft_dim will be 125
+```

--- a/docs/poisson_3d_fft/doc_poisson_solver.f90.md
+++ b/docs/poisson_3d_fft/doc_poisson_solver.f90.md
@@ -1,0 +1,186 @@
+# `poisson_solver.f90` (Module `Poisson_Solver`)
+
+## Overview
+
+The `Poisson_Solver` module is a comprehensive package designed to solve the Poisson equation, typically $\nabla^2 V(\mathbf{x}) = -4\pi \rho(\mathbf{x})$ (though the $4\pi$ factor might be handled by scaling within the solver or kernel), using Fast Fourier Transform (FFT) methods in three dimensions. This solver is versatile, supporting various boundary conditions crucial for different physical scenarios:
+-   **'F' (Free):** For isolated systems where the potential decays to zero at infinity.
+-   **'S' (Surface):** For systems periodic in two dimensions (xz-plane) but isolated in the third (y-direction).
+-   **'P' (Periodic):** For systems periodic in all three dimensions.
+
+The module is structured as a primary Fortran module file (`poisson_solver.f90`) that includes several other `.f90` files, each encapsulating specific parts of the solver's functionality, such as kernel generation, the main FFT solution process, exchange-correlation (XC) calculations, gradient computations, low-level FFTs, and the generation of interpolating scaling functions. It also integrates MPI for parallel execution and data distribution. This solver is notably used by the `m_free_space` module within the `m_octree_mg` library to handle open boundary conditions.
+
+## Key Components
+
+### Module Definition
+-   **`Poisson_Solver`**: The main module a user interacts with. It re-exports public entities from the included files.
+
+### Public Module Variable
+-   **`iproc_verbose (integer)`**: A control variable for verbosity. If set to `0` (typically for MPI rank 0), additional information about the solver's execution may be printed. Default is `-1` (no verbose output).
+
+### Public Subroutines
+
+-   **`createKernel(geocode, n01, n02, n03, hx, hy, hz, itype_scf, iproc, nproc, kernel)`**:
+    -   **Description:** This subroutine is responsible for allocating and computing the Poisson kernel (Green's function) in reciprocal (Fourier) space. The kernel's form depends on the specified boundary conditions (`geocode`) and the order of interpolating scaling functions (`itype_scf`) used for its construction.
+        - For 'P' (Periodic BCs), the kernel is analytical ($1/k^2$) and this routine might perform minimal setup.
+        - For 'F' (Free BCs) and 'S' (Surface BCs), the construction is more involved, often utilizing interpolating scaling functions to represent the Green's function and Gaussian quadrature for related integrals. This logic is primarily found within `build_kernel.f90`.
+    -   **Arguments (Key):**
+        -   `geocode (character(len=1), intent(in))`: Boundary condition type ('F', 'S', or 'P').
+        -   `n01, n02, n03 (integer, intent(in))`: Global dimensions of the real-space grid.
+        -   `hx, hy, hz (real(kind=8), intent(in))`: Grid spacings.
+        -   `itype_scf (integer, intent(in))`: Order of interpolating scaling functions.
+        -   `iproc, nproc (integer, intent(in))`: MPI rank and total number of processes.
+        -   `kernel (real(kind=8), pointer, intent(out))`: Output pointer to the allocated and computed kernel array in reciprocal space.
+    -   **Primary Included File:** `build_kernel.f90`.
+
+-   **`PSolver(geocode, datacode, iproc, nproc, n01, n02, n03, ixc, hx, hy, hz, rhopot, karray, pot_ion, eh, exc, vxc, offset, sumpion, nspin)`**:
+    -   **Description:** This is the main solver routine. Given a density distribution $\rho$ (in `rhopot` on input), it computes the electrostatic potential $V$ by:
+        1.  Performing a forward 3D FFT on $\rho$.
+        2.  Multiplying the result by the pre-computed `karray` (the Green's function $G(k)$) in reciprocal space.
+        3.  Performing an inverse 3D FFT to obtain $V(\mathbf{x})$.
+        The routine handles different data distributions (`datacode`: 'G' for global, 'D' for distributed data across MPI processes) and boundary conditions (`geocode`). It can optionally compute exchange-correlation (XC) energies and potentials if `ixc /= 0` (interfacing with ABINIT's XC library) and can add an external ionic potential (`pot_ion`) to the result.
+    -   **Arguments (Key):**
+        -   `geocode, datacode (character(len=1), intent(in))`: Boundary and data distribution codes.
+        -   `iproc, nproc, n01, n02, n03 (integer, intent(in))`: MPI and grid dimension parameters.
+        -   `ixc (integer, intent(in))`: Exchange-correlation functional code (0 for none).
+        -   `hx, hy, hz (real(kind=8), intent(in))`: Grid spacings.
+        -   `rhopot (real(kind=8), dimension(*), intent(inout))`: On input, contains the density $\rho$. On output, it's overwritten with the computed potential $V_H (+ V_{XC} + V_{ion}$ if applicable).
+        -   `karray (real(kind=8), dimension(*), intent(in))`: The pre-computed Poisson kernel from `createKernel`.
+        -   `pot_ion (real(kind=8), dimension(*), intent(inout))`: External ionic potential / XC potential output.
+        -   `eh, exc, vxc (real(kind=8), intent(out))`: Hartree energy, XC energy, and $\int \rho V_{XC} d\mathbf{x}$.
+        -   `offset (real(kind=8), intent(in))`: Potential offset for periodic calculations.
+        -   `sumpion (logical, intent(in))`: If true and `ixc /=0`, adds `pot_ion` to `rhopot`.
+        -   `nspin (integer, intent(in))`: Number of spin components (1 or 2).
+    -   **Primary Included Files:** `psolver_main.f90` (defines `PSolver`), `psolver_base.f90` (specific P/S/F solvers), `xcenergy.f90`, `3dgradient.f90`, `fft3d.f90`.
+
+-   **`PS_dim4allocation(geocode, datacode, iproc, nproc, n01, n02, n03, ixc, n3d, n3p, n3pi, i3xcsh, i3s)`**:
+    -   **Description:** Calculates the necessary array dimensions for `rhopot` and `pot_ion` based on the problem setup (boundary conditions, data distribution, XC functional, MPI configuration). This is crucial for users to correctly allocate memory before calling `PSolver`, especially when data is distributed or XC calculations require larger ghost regions for gradients.
+    -   **Arguments (Key outputs):**
+        -   `n3d, n3p, n3pi (integer, intent(out))`: Calculated third dimensions for density, potential, and ionic potential arrays for the current process.
+        -   `i3xcsh, i3s (integer, intent(out))`: Shifts and starting indices for array slicing, especially relevant for GGA XC calculations with distributed data.
+    -   **Primary Included File:** `psolver_main.f90` (which calls `P/S/F_FFT_dimensions`).
+
+-   **`P_FFT_dimensions`, `S_FFT_dimensions`, `F_FFT_dimensions`**:
+    -   **Description:** Helper subroutines, likely made public through `PS_dim4allocation` or available directly, that determine the padded FFT grid dimensions (`n1, n2, n3`), real-space data dimensions (`md1, md2, md3`), and reciprocal-space kernel dimensions (`nd1, nd2, nd3`) required for the specified boundary conditions ('P', 'S', or 'F') and original grid sizes (`n01, n02, n03`). These ensure that array dimensions are compatible with FFT algorithms (e.g., products of small primes) and MPI data distribution.
+    -   **Primary Included File:** `psolver_main.f90`.
+
+### Role of Included Files
+
+The `Poisson_Solver` module achieves its functionality by including several source files:
+-   **`psolver_main.f90`**: Contains the main `PSolver` routine, which acts as a dispatcher to boundary-condition-specific routines, and the `PS_dim4allocation` routine with its helpers (`P/S/F_FFT_dimensions`).
+-   **`build_kernel.f90`**: Contains `createKernel` and its helper subroutines (`Free_Kernel`, `Surfaces_Kernel`, `calculates_green_opt`, `calculates_green_opt_muzero`, `gequad`, `kernelfft`, `inserthalf`). It is responsible for constructing the $G(k)$ kernel, often using interpolating scaling functions (see `scaling_function.f90`) for 'F' and 'S' boundary conditions.
+-   **`psolver_base.f90`**: Contains the core FFT-based solution algorithms for each boundary condition type: `P_PoissonSolver`, `S_PoissonSolver`, and `F_PoissonSolver`. These routines handle the forward FFT of density, multiplication by the kernel in Fourier space, and the backward FFT to get the potential. They also manage data transpositions and MPI communication patterns specific to the 3D FFTs.
+-   **`xcenergy.f90`**: Contains `xc_energy` which interfaces with an external XC library (like ABINIT's) to compute exchange-correlation energy and potential if `ixc /= 0`. It also includes `vxcpostprocessing` for applying White-Bird corrections for GGA functionals.
+-   **`3dgradient.f90`**: Contains `calc_gradient` to compute density gradients needed for GGA XC functionals, and `wb_correction` which is part of the White-Bird correction scheme.
+-   **`fft3d.f90`**: Provides the low-level 1D FFT routine (`fftstp`) used by the 3D FFTs, and `ctrig` to precompute trigonometric factors. It also includes `fourier_dim` to determine FFT-friendly dimensions.
+-   **`scaling_function.f90`**: Contains routines like `scaling_function`, `wavelet_function`, and various `*_trans_*` and `scf_recursion_*` subroutines. These are used to compute the values of interpolating scaling functions of different orders, which are then used in `build_kernel.f90` for constructing accurate Green's functions for non-periodic boundary conditions.
+
+## Important Variables/Constants
+
+-   **`iproc_verbose (integer, public)`**: Module variable to control verbose output (typically rank 0 prints if `iproc_verbose == 0`).
+-   **`geocode (character(len=1))`**: Input to `PSolver` and `createKernel`, specifies boundary conditions: 'F' (Free), 'S' (Surface), 'P' (Periodic).
+-   **`datacode (character(len=1))`**: Input to `PSolver`, specifies data layout: 'G' (Global - all data on all procs), 'D' (Distributed).
+-   **`ixc (integer)`**: Input to `PSolver`, specifies the exchange-correlation functional to use (ABINIT convention, 0 means no XC).
+-   **`itype_scf (integer)`**: Input to `createKernel`, defines the order of interpolating scaling functions used in kernel construction (e.g., 8, 14, 16).
+
+## Dependencies and Interactions
+
+-   **External Dependencies:**
+    -   **MPI:** Heavily used throughout for parallel data distribution, FFTs, and global reductions (e.g., `MPI_ALLTOALL`, `MPI_ALLGATHERV`, `MPI_ALLREDUCE`, `MPI_BCAST`).
+    -   **ABINIT Modules (referenced in comments):** `defs_xc`, `defs_basis`, `defs_datatypes`. These are required if `ixc /= 0` for exchange-correlation calculations. They are not part of the `poisson_3d_fft` package itself.
+-   **Internal Dependencies (Inter-file within the module):**
+    -   `poisson_solver.f90` acts as the main include file.
+    -   `psolver_main.f90` calls routines in `psolver_base.f90` and `xcenergy.f90`.
+    -   `build_kernel.f90` calls routines in `scaling_function.f90` and `fft3d.f90` (for `kernelfft`).
+    -   `psolver_base.f90` calls routines in `fft3d.f90`.
+    -   `xcenergy.f90` calls `drivexc` (external ABINIT interface) and routines in `3dgradient.f90`.
+-   **Interaction with `m_octree_mg` library:**
+    -   The `m_free_space` module of the `m_octree_mg` library uses `Poisson_Solver`'s `createKernel` and `PSolver` subroutines. This is typically done to solve the Poisson equation on the coarsest grid level of the multigrid hierarchy when free-space (open) boundary conditions are needed for the overall problem. The FFT solver provides the global solution component, which then informs the boundary conditions for the multigrid solver on finer levels.
+
+## Usage Examples
+
+The "QUICK INSTRUCTION FOR THE IMPATIENT" in `poisson_solver.f90` provides a good starting point:
+
+```fortran
+! Conceptual Example: Solving Poisson's equation using Poisson_Solver
+! (Assumes serial execution for simplicity in this example, but designed for MPI)
+
+module MyPoissonProblem
+  use Poisson_Solver
+  use mpi ! Poisson_Solver itself uses MPI, so an MPI environment is expected.
+  implicit none
+
+  subroutine solve_density_for_potential()
+    real(kind=8), pointer :: kernel_array(:)
+    real(kind=8), dimension(:,:,:), allocatable :: rhopot_data
+    real(kind=8) :: hartree_energy, hx_spacing, hy_spacing, hz_spacing
+    real(kind=8) :: dummy_exc, dummy_vxc, offset_val
+    integer :: nx_dim, ny_dim, nz_dim, ierr
+    integer :: my_rank, num_procs
+    character(len=1) :: geometry_code
+    logical :: sum_ionic_potential
+    integer :: xc_functional_code, spin_components
+
+    ! Initialize MPI
+    call MPI_Init(ierr)
+    call MPI_Comm_rank(MPI_COMM_WORLD, my_rank, ierr)
+    call MPI_Comm_size(MPI_COMM_WORLD, num_procs, ierr)
+
+    ! Define grid parameters
+    nx_dim = 64; ny_dim = 64; nz_dim = 64  ! Example dimensions
+    hx_spacing = 0.5d0; hy_spacing = 0.5d0; hz_spacing = 0.5d0
+    geometry_code = 'F' ! Free boundary conditions
+
+    ! Allocate and initialize density data (rhopot_data)
+    ! For 'G' (Global) datacode, full array on all procs.
+    ! For 'D' (Distributed), use PS_dim4allocation to get local sizes.
+    ! For simplicity, assuming global allocation here.
+    allocate(rhopot_data(nx_dim, ny_dim, nz_dim))
+    ! ... Fill rhopot_data with density values ...
+    rhopot_data = 1.0d0 ! Example: uniform density
+
+    ! 1. Create the Poisson Kernel
+    !    itype_scf=14 is a common choice mentioned.
+    !    (kernel_array is a pointer, createKernel will allocate it)
+    call createKernel(geometry_code, nx_dim, ny_dim, nz_dim, &
+                      hx_spacing, hy_spacing, hz_spacing, &
+                      14, my_rank, num_procs, kernel_array)
+
+    ! 2. Solve for the potential
+    xc_functional_code = 0  ! No XC calculation
+    offset_val = 0.0d0      ! No offset for Free BC
+    sum_ionic_potential = .false.
+    spin_components = 1
+
+    ! PSolver will overwrite rhopot_data with the potential.
+    ! dummy_array for pot_ion (not used here as ixc=0 and sumpion=false)
+    ! For actual use, pot_ion might need proper allocation if ixc/=0
+    call PSolver(geometry_code, 'G', my_rank, num_procs, &
+                 nx_dim, ny_dim, nz_dim, xc_functional_code, &
+                 hx_spacing, hy_spacing, hz_spacing, &
+                 rhopot_data, kernel_array, rhopot_data(1,1,1) , & ! Dummy pot_ion
+                 hartree_energy, dummy_exc, dummy_vxc, &
+                 offset_val, sum_ionic_potential, spin_components)
+
+    if (my_rank == 0) then
+      print *, "Poisson solve complete."
+      print *, "Hartree Energy: ", hartree_energy
+      ! rhopot_data now contains the electrostatic potential.
+      ! ... (Process the potential data) ...
+    end if
+
+    ! Deallocate kernel
+    if (associated(kernel_array)) deallocate(kernel_array)
+    deallocate(rhopot_data)
+
+    call MPI_Finalize(ierr)
+
+  end subroutine solve_density_for_potential
+
+end module MyPoissonProblem
+
+program TestPoisson
+  use MyPoissonProblem
+  implicit none
+  call solve_density_for_potential()
+end program TestPoisson
+```

--- a/docs/poisson_3d_fft/doc_psolver_main.f90.md
+++ b/docs/poisson_3d_fft/doc_psolver_main.f90.md
@@ -1,0 +1,171 @@
+# `psolver_main.f90`
+
+## Overview
+
+The `psolver_main.f90` file is a central piece of the `Poisson_Solver` module, designed to be `include`d within the main `poisson_solver.f90` file. Its primary contribution is the `PSolver` subroutine, which orchestrates the entire process of solving Poisson's equation ($\nabla^2 V = -4\pi\rho$, or variations depending on internal scaling) using Fast Fourier Transform (FFT) techniques.
+
+`PSolver` is a versatile routine that handles various boundary conditions (Periodic, Surface, Free), different data distribution schemes for parallel processing (Global or Distributed), and can optionally incorporate exchange-correlation (XC) potentials and energies by interfacing with external XC libraries (like ABINIT's). This file also contains crucial helper subroutines for determining the appropriate dimensions for FFT grids and data arrays based on the problem's configuration: `PS_dim4allocation`, and the boundary-specific `P_FFT_dimensions`, `S_FFT_dimensions`, and `F_FFT_dimensions`.
+
+## Key Components
+
+### File Type
+A collection of Fortran subroutines, intended for direct inclusion into `poisson_solver.f90`. It does not define a standalone Fortran `module`.
+
+### Main Subroutine
+
+-   **`PSolver(geocode, datacode, iproc, nproc, n01, n02, n03, ixc, hx, hy, hz, rhopot, karray, pot_ion, eh, exc, vxc, offset, sumpion, nspin)`**:
+    -   **Description:** This is the main driver routine for solving Poisson's equation. Its operation can be summarized as:
+        1.  **Dimension Calculation:** Determines optimal FFT grid dimensions (`n1,n2,n3`), padded real-space dimensions (`md1,md2,md3`), and kernel dimensions (`nd1,nd2,nd3`) by calling the appropriate `P/S/F_FFT_dimensions` routine based on the `geocode`.
+        2.  **Memory Allocation:** Allocates local work arrays, primarily `zf` (to hold the density for FFT and then the potential) and `zfionxc` (for XC/ionic potentials).
+        3.  **Exchange-Correlation (Optional):** If `ixc /= 0`, it calls `xc_energy` (from `xcenergy.f90`). `xc_energy` computes the XC energy and potential, potentially involving gradient calculations (via `3dgradient.f90`) if a GGA functional is selected. The input density from `rhopot` is appropriately processed (e.g., distributed, padded) and placed into `zf`.
+        4.  **Core FFT Solve:** Calls the boundary-condition-specific solver routine (`P_PoissonSolver`, `S_PoissonSolver`, or `F_PoissonSolver` from `psolver_base.f90`). These routines perform the three main steps:
+            a.  Forward 3D FFT of the density (from `zf`).
+            b.  Multiplication in reciprocal space by the pre-computed `karray` (the $G(k)$ kernel).
+            c.  Inverse 3D FFT to transform the result back to real space, yielding the Hartree potential (stored back in `zf`).
+        5.  **Potential Correction & Combination:** The computed Hartree potential is corrected (e.g., for `offset` in periodic systems). If XC calculations were performed, the XC potential (from `zfionxc`) is added. If `sumpion` is true, the external `pot_ion` is also added. The final combined potential is stored in the output `rhopot` array.
+        6.  **Energy Calculation:** The Hartree energy (`eh`) and XC related energies (`exc`, `vxc`) are computed locally and then summed across all MPI processes using `MPI_ALLREDUCE`.
+        7.  **Data Gathering (Optional):** If `datacode = 'G'` (global data), the final potential in `rhopot` (and `pot_ion` if modified) is gathered from all MPI processes to all processes using `MPI_ALLGATHERV`.
+    -   **Key Arguments:**
+        -   `geocode (character(len=1), intent(in))`: Boundary condition type ('F', 'S', 'P').
+        -   `datacode (character(len=1), intent(in))`: Data distribution type ('G' for global, 'D' for distributed).
+        -   `iproc, nproc (integer, intent(in))`: MPI rank of the current process and total number of processes.
+        -   `n01, n02, n03 (integer, intent(in))`: Global dimensions of the original real-space grid.
+        -   `ixc (integer, intent(in))`: Code for the exchange-correlation functional (0 for none; ABINIT convention).
+        -   `hx, hy, hz (real(kind=8), intent(in))`: Grid spacings in x, y, z directions.
+        -   `rhopot (real(kind=8), dimension(*), intent(inout))`: On input, this array holds the source density $\rho$. On output, it is overwritten with the computed potential $V_H$ (plus $V_{XC}$ and $V_{ion}$ if applicable). Its actual dimensions depend on `datacode` and must be consistent with `PS_dim4allocation`.
+        -   `karray (real(kind=8), dimension(*), intent(in))`: The pre-computed Poisson kernel $G(k)$ in reciprocal space, obtained from `createKernel`.
+        -   `pot_ion (real(kind=8), dimension(*), intent(inout))`: If `ixc /= 0` and `sumpion` is `.false.`, this array is overwritten with $V_{XC}$. If `sumpion` is `.true.`, this array provides an input ionic/external potential that is added to the final result in `rhopot`.
+        -   `eh (real(kind=8), intent(out))`: Calculated Hartree energy ($1/2 \int \rho V_H d\mathbf{x}$).
+        -   `exc (real(kind=8), intent(out))`: Calculated exchange-correlation energy $E_{XC}$.
+        -   `vxc (real(kind=8), intent(out))`: Calculated $\int \rho V_{XC} d\mathbf{x}$.
+        -   `offset (real(kind=8), intent(in))`: A constant potential offset to be applied, primarily for periodic systems.
+        -   `sumpion (logical, intent(in))`: If `.true.` and `ixc /=0`, `pot_ion` (input) is added to the final potential in `rhopot`.
+        -   `nspin (integer, intent(in))`: Number of spin components (1 for non-spin-polarized, 2 for spin-polarized).
+
+### Dimension Calculation Subroutines
+
+-   **`PS_dim4allocation(geocode, datacode, iproc, nproc, n01, n02, n03, ixc, n3d, n3p, n3pi, i3xcsh, i3s)`**:
+    -   **Description:** This routine is crucial for users to determine the correct sizes for allocating the `rhopot` and `pot_ion` arrays, especially for distributed data (`datacode='D'`) and when GGA XC functionals (`ixc >= 11`) are used, as these require larger halo regions for gradient computations. It calls one of `P/S/F_FFT_dimensions` based on `geocode` to get base FFT and real-space dimensions, then adjusts these based on `ixc` and `datacode`.
+    -   **Key Output Arguments:**
+        -   `n3d (integer, intent(out))`: The required size of the third dimension for the `rhopot` array (holding density) on the current process.
+        -   `n3p (integer, intent(out))`: The required size of the third dimension for the `rhopot` array (when it holds potential) on the current process.
+        -   `n3pi (integer, intent(out))`: The required size of the third dimension for the `pot_ion` array on the current process.
+        -   `i3xcsh (integer, intent(out))`: The shift in the third dimension index needed to access the non-overlapping part of the potential when XC gradients are involved.
+        -   `i3s (integer, intent(out))`: The starting global plane index in the third dimension for the data slice handled by the current process.
+
+-   **`P_FFT_dimensions(n01,n02,n03,m1,m2,m3,n1,n2,n3,md1,md2,md3,nd1,nd2,nd3,nproc)`**
+-   **`S_FFT_dimensions(...)`**
+-   **`F_FFT_dimensions(...)`**
+    -   **Description:** These helper subroutines calculate various sets of dimensions required for FFTs under Periodic, Surface, or Free boundary conditions, respectively.
+        -   `m1,m2,m3`: Real-space dimensions, with `m2=n03` and `m3=n02` (a convention used internally, possibly y-z swap).
+        -   `n1,n2,n3`: Padded dimensions suitable for FFT (e.g., products of small primes from `fourier_dim`). For 'F' and 'S', these are typically doubled for zero-padding or handling non-periodic directions.
+        -   `md1,md2,md3`: Dimensions of the real-space data arrays used in FFTs, potentially adjusted for MPI distribution (e.g., `md2` might be made a multiple of `nproc`).
+        -   `nd1,nd2,nd3`: Dimensions for the kernel array in reciprocal space (often half-dimensions due to symmetries), adjusted for MPI distribution.
+    -   They utilize `fourier_dim` (from `fft3d.f90`) to find FFT-compatible lengths.
+
+## Important Variables/Constants
+
+-   **`nordgr (integer, parameter)` in `PSolver`**: Defines the order for finite-difference gradient calculations (fixed to 4), relevant for GGA XC functionals.
+-   **Internal work arrays `zf` and `zfionxc`**: Dynamically allocated within `PSolver` to hold data during FFT operations and for XC potential components.
+-   **MPI tags**: Standard MPI tag 0 is used for communications within `PSolver`.
+
+## Dependencies and Interactions
+
+-   **Internal (within `Poisson_Solver` module via `include` mechanism):**
+    -   `PSolver` calls `P/S/F_FFT_dimensions` (defined in the same file).
+    -   If `ixc /= 0`, `PSolver` calls `xc_energy` (from `xcenergy.f90`).
+    -   `PSolver` calls one of `P_PoissonSolver`, `S_PoissonSolver`, or `F_PoissonSolver` (from `psolver_base.f90`) to perform the core FFT-based solution.
+    -   The `P/S/F_FFT_dimensions` routines call `fourier_dim` (from `fft3d.f90`).
+-   **External Libraries:**
+    -   **MPI:** Heavily used in `PSolver` for global communication: `MPI_BCAST` (for potential offset in periodic case), `MPI_ALLREDUCE` (for summing energies), and `MPI_ALLGATHERV` (if `datacode='G'` to ensure all processes have the full result).
+-   **Interactions with Other Components:**
+    -   `PSolver` is the primary computational routine of the `Poisson_Solver` module. It expects the $G(k)$ kernel to have been pre-calculated by `createKernel` (from `build_kernel.f90`).
+    -   The dimensions of input arrays `rhopot` and `pot_ion` must be determined using `PS_dim4allocation` to ensure compatibility, especially in parallel and with XC calculations.
+    -   This entire `Poisson_Solver` package is used by the `m_free_space` module within the `m_octree_mg` library to compute the far-field potential for open boundary conditions, typically on the coarsest grid of the multigrid hierarchy.
+
+## Usage Examples
+
+The `PSolver` subroutine is complex due to its many options. A typical invocation sequence involves first determining array sizes, then creating the kernel, then calling the solver.
+
+```fortran
+! Conceptual Example: Using PSolver after kernel creation.
+
+module ExampleFullPoissonSolve
+  use Poisson_Solver ! Provides PSolver, PS_dim4allocation, createKernel
+  use mpi
+  implicit none
+
+  subroutine run_fft_poisson_solve()
+    real(kind=8), pointer :: kernel_data(:)
+    real(kind=8), dimension(:,:,:), allocatable :: density_potential_3d_array
+    real(kind=8), dimension(:,:,:), allocatable :: ionic_potential_3d_array ! Or for Vxc output
+    real(kind=8) :: hx, hy, hz, hartree_energy, xc_energy_val, vxc_integral_val, potential_offset
+    integer :: nx, ny, nz, mpi_rank_id, num_mpi_procs, xc_func_id
+    integer :: n3d_local, n3p_local, n3pi_local, i3xc_shift, i3_start_plane, mpi_err
+    character(len=1) :: bc_geocode, data_layout_code
+    logical :: add_ionic_potential_to_hartree
+
+    ! 1. Initialize MPI and basic parameters
+    call MPI_Init(mpi_err)
+    call MPI_Comm_rank(MPI_COMM_WORLD, mpi_rank_id, mpi_err)
+    call MPI_Comm_size(MPI_COMM_WORLD, num_mpi_procs, mpi_err)
+
+    nx = 96; ny = 96; nz = 96       ! Global grid dimensions
+    hx = 0.2d0; hy = 0.2d0; hz = 0.2d0 ! Grid spacings
+    bc_geocode = 'F'              ! Free boundary conditions
+    data_layout_code = 'D'        ! Distributed data
+    xc_func_id = 0                ! 0 for no exchange-correlation
+    add_ionic_potential_to_hartree = .false.
+    potential_offset = 0.0d0      ! Usually for periodic systems
+
+    ! 2. Determine allocation sizes for distributed arrays
+    call PS_dim4allocation(bc_geocode, data_layout_code, mpi_rank_id, num_mpi_procs, &
+                           nx, ny, nz, xc_func_id, &
+                           n3d_local, n3p_local, n3pi_local, i3xc_shift, i3_start_plane)
+
+    ! 3. Allocate arrays based on determined local sizes
+    !    Note: Dimensions might be swapped internally by FFT routines (n02, n03 often swapped)
+    !    For simplicity, using n01, n02, n3d_local (actual mapping is complex)
+    allocate(density_potential_3d_array(nx, ny, n3d_local)) ! Using n01,n02 for first two dims
+    allocate(ionic_potential_3d_array(nx, ny, n3pi_local))  ! Same for pot_ion
+    density_potential_3d_array = 0.0d0
+    ionic_potential_3d_array = 0.0d0
+    ! ... Fill the local slice of density_potential_3d_array with density values ...
+    ! ... (from i3_start_plane to i3_start_plane + n3d_local - 1) ...
+
+    ! 4. Create the Poisson kernel
+    !    (itype_scf=14 is a common choice for scaling functions)
+    call createKernel(bc_geocode, nx, ny, nz, hx, hy, hz, &
+                      14, mpi_rank_id, num_mpi_procs, kernel_data)
+
+    ! 5. Call the Poisson Solver
+    call PSolver(bc_geocode, data_layout_code, mpi_rank_id, num_mpi_procs, &
+                 nx, ny, nz, xc_func_id, hx, hy, hz, &
+                 density_potential_3d_array, kernel_data, ionic_potential_3d_array, &
+                 hartree_energy, xc_energy_val, vxc_integral_val, &
+                 potential_offset, add_ionic_potential_to_hartree, 1) ! nspin=1
+
+    ! 6. Results
+    !    density_potential_3d_array now contains the computed electrostatic potential
+    !    (potentially plus XC and ionic contributions based on flags).
+    !    hartree_energy, xc_energy_val, vxc_integral_val contain calculated energies.
+    if (mpi_rank_id == 0) then
+      print *, "PSolver finished. Hartree Energy:", hartree_energy
+    end if
+
+    ! 7. Deallocate
+    if (associated(kernel_data)) deallocate(kernel_data)
+    deallocate(density_potential_3d_array)
+    deallocate(ionic_potential_3d_array)
+
+    call MPI_Finalize(mpi_err)
+
+  end subroutine run_fft_poisson_solve
+end module ExampleFullPoissonSolve
+
+program TestPoissonSolverMain
+  use ExampleFullPoissonSolve
+  implicit none
+  call run_fft_poisson_solve()
+end program TestPoissonSolverMain
+```

--- a/docs/single_module/doc_m_free_space_single_module.f90.md
+++ b/docs/single_module/doc_m_free_space_single_module.f90.md
@@ -1,0 +1,161 @@
+# `m_free_space.f90` (from `single_module` directory)
+
+## Overview
+
+The `m_free_space` module, specifically the version found in the `single_module` directory, provides specialized functionality to solve 3D Poisson's equation ($\nabla^2 \phi = \rho$) under free-space (open or unbounded) boundary conditions. It is designed to be compiled and used in conjunction with the `m_octree_mg_3d` module, which is the single-file, 3D version of the core `octree-mg` library.
+
+This module employs a hybrid solution strategy. It utilizes an external FFT-based Poisson solver (from the `Poisson_Solver` package located in `poisson_3d_fft/`) to compute the global, far-field solution on a selected (potentially coarser) grid level within the `octree-mg` hierarchy. The potential values derived from this global FFT solution are then used to set Dirichlet boundary conditions for the main `octree-mg_3d` multigrid solver. This approach allows the `octree-mg` library to handle problems where the computational domain is effectively infinite, rather than being confined by simple periodic or fixed-value boundaries. This module is only functional for 3D problems.
+
+## Key Components
+
+### Modules
+
+-   **`m_free_space`**: The Fortran module defined in this file.
+
+### Internal Derived Type
+
+-   **`mg_free_bc_t` (private)**: This derived type is used internally to store the state and data associated with the free-space boundary condition calculation. Its key components include:
+    -   `initialized (logical)`: A flag indicating whether the FFT-derived boundary data has been computed.
+    -   `fft_lvl (integer)`: The level within the `m_octree_mg_3d` grid hierarchy on which the global FFT solve was performed.
+    -   `rhs (real(dp), allocatable, :,:,:)`: Stores the right-hand side (source term $\rho$), restricted from the main grid and padded as necessary for the FFT solver.
+    -   `karray (real(dp), pointer, :)`: A pointer to the reciprocal space Poisson kernel ($G(k)$) computed by and used by the `Poisson_Solver` module.
+    -   `inv_dr(2, mg_num_neighbors) (real(dp))`, `r_min(2, mg_num_neighbors) (real(dp))`: Inverse grid spacings and minimum coordinates for the boundary planes of the FFT domain, used for interpolating boundary values.
+    -   `bc_x0, bc_x1, bc_y0, bc_y1, bc_z0, bc_z1 (real(dp), allocatable, :,:)`: Arrays that store the potential values on the six faces of the FFT domain, derived from the `Poisson_Solver` solution. These values are then used as Dirichlet boundary conditions for the `m_octree_mg_3d` solver.
+
+### Module Variable (State)
+
+-   **`free_bc (type(mg_free_bc_t))` (private)**: A module-level variable of type `mg_free_bc_t` that holds the persistent state of the free-space boundary calculation across calls to `mg_poisson_free_3d`.
+
+### Public Subroutines
+
+-   **`mg_poisson_free_3d(mg, new_rhs, max_fft_frac, fmgcycle, max_res)`**:
+    -   **Description:** This is the main public subroutine for solving the 3D Poisson equation with free-space boundary conditions.
+        1.  **Pre-checks:** Verifies that the geometry is Cartesian (`mg%geometry_type == mg_cartesian`) and the operator is Laplacian (`mg%operator_type == mg_laplacian`).
+        2.  **FFT Level Selection:** Determines an appropriate `fft_lvl` for the global FFT solve. This level is chosen such that its number of unknowns is a certain fraction (`max_fft_frac`) of the total unknowns on the finest leaf level of the `mg` structure.
+        3.  **Kernel and RHS Preparation (if `new_rhs` or `fft_lvl` changed):**
+            -   Restricts the source term from `mg%boxes(:)%cc(..., mg_irhs)` down to the selected `fft_lvl`.
+            -   Calls `createKernel` from the `poisson_solver` module to generate the free-space Green's function in reciprocal space (`free_bc%karray`).
+            -   Prepares the right-hand side `free_bc%rhs` for `PSolver` by gathering data from all MPI processes (using `MPI_ALLREDUCE`) and applying a scaling factor (`rhs_fac`).
+        4.  **Global Solve:** Calls `PSolver` from the `poisson_solver` module to obtain the potential on the `fft_lvl` grid.
+        5.  **Boundary Extraction:** Extracts potential values from the faces of the `fft_lvl` solution domain and stores them in `free_bc%bc_x0, ...` after interpolation.
+        6.  **Boundary Condition Setup:** Calls `mg_phi_bc_store` (from `m_octree_mg_3d`) to register these computed boundary values. It also sets the `mg%bc(n, mg_iphi)%boundary_cond` procedure pointer to the local `ghost_cells_free_bc` routine.
+        7.  **Initial Guess:** Uses the `PSolver` solution on `fft_lvl` as an initial guess for `mg_iphi`, then restricts and prolongs this guess to other levels of the `mg` hierarchy.
+        8.  **Multigrid Solve:** If the `fft_lvl` is not the highest (finest) level in the `mg` structure, it calls the main multigrid solver (`mg_fas_fmg` or `mg_fas_vcycle` from `m_octree_mg_3d`) to refine the solution using the `octree-mg` framework with the newly defined boundary conditions.
+    -   **Key Arguments:**
+        -   `mg (type(mg_t), intent(inout))`: The main multigrid data structure from `m_octree_mg_3d`.
+        -   `new_rhs (logical, intent(in))`: Flag indicating if the source term (`mg_irhs`) has changed or if it's the first call, triggering recalculation of the FFT solution.
+        -   `max_fft_frac (real(dp), intent(in))`: Fraction (0.0-1.0) determining the relative size of the coarse grid used for the FFT solve compared to the full grid.
+        -   `fmgcycle (logical, intent(in))`: If `.true.`, an FMG cycle is used for the `octree-mg` solve; otherwise, a V-cycle is used.
+        -   `max_res (real(dp), intent(out), optional)`: If present, returns the maximum residual from the `octree-mg` solver.
+
+### Private Helper Subroutines
+
+-   **`ghost_cells_free_bc(box, nc, iv, nb, bc_type, bc)`**:
+    -   **Description:** This routine is assigned to the `mg%bc(n, mg_iphi)%boundary_cond` procedure pointer. When the `m_octree_mg_3d` library fills ghost cells for a box at what it considers a physical boundary, this subroutine is called. It sets `bc_type = mg_bc_dirichlet` and uses `interp_bc` to determine the ghost cell values by interpolating from the appropriate boundary plane data (e.g., `free_bc%bc_x0`) that was pre-computed by `PSolver`.
+    -   **Arguments:** Standard signature for `mg_subr_bc` (from `m_data_structures`).
+
+-   **`interp_bc(bc_data, nb, x1, x2) elemental function result(val)`**:
+    -   **Description:** An elemental function that performs bilinear interpolation. Given coordinates `x1, x2` on a specific boundary face `nb`, it interpolates the potential value `val` from the corresponding pre-calculated boundary data array (e.g., `bc_data%bc_x0`) stored in the `mg_free_bc_t` type variable.
+    -   **Arguments:**
+        -   `bc_data (type(mg_free_bc_t), intent(in))`: The stored free boundary condition data.
+        -   `nb (integer, intent(in))`: Neighbor index indicating the boundary face.
+        -   `x1, x2 (real(dp), intent(in))`: Coordinates on the boundary plane.
+        -   `val (real(dp))`: The interpolated potential value.
+
+## Important Variables/Constants
+
+-   **`free_bc (type(mg_free_bc_t))`**: Internal module variable holding the state for the free-space solver.
+-   **`rhs_fac (real(dp), parameter)`**: Value of `-1.0_dp / (4 * acos(-1.0_dp))` (i.e., $-1/(4\pi)$). This scales the source term `mg_irhs` before it's passed to the `PSolver`, aligning with the Green's function definition $\nabla^2 G = -4\pi \delta(\mathbf{r})$ implicitly used by `PSolver`.
+-   **Hardcoded parameters for `PSolver` call:**
+    -   `geocode = 'F'` (Free boundary conditions).
+    -   `datacode = 'G'` (Global data layout for the `PSolver` call's perspective on `free_bc%rhs`).
+    -   `itype_scf = 8` (Order of interpolating scaling functions for `createKernel`).
+    -   `ixc = 0` (No exchange-correlation calculation within this context).
+
+## Dependencies and Interactions
+
+-   **`use m_octree_mg_3d`**: This is the primary dependency. It provides the `mg_t` derived type, core multigrid routines (`mg_fas_fmg`, `mg_fas_vcycle`, `mg_restrict_lvl`, `mg_prolong`, `mg_fill_ghost_cells_lvl`, `mg_phi_bc_store`, `mg_number_of_unknowns`, `mg_highest_uniform_lvl`, `mg_get_face_coords`), and all associated constants (like `mg_iphi`, `mg_irhs`, `mg_laplacian`, `mg_cartesian`, `mg_bc_dirichlet`, `mg_num_neighbors`, `mg_neighb_dim`, `mg_neighb_lowx`, etc.).
+-   **`use poisson_solver`**: This module (located in the `poisson_3d_fft/` directory) is crucial. `mg_poisson_free_3d` calls `createKernel` and `PSolver` from it to perform the underlying FFT-based Poisson solve on the selected coarse `fft_lvl`.
+-   **`use mpi`**: Used for MPI communication, specifically `MPI_ALLREDUCE` to sum the RHS from all processes before the `PSolver` call.
+-   **Interaction with `mg_t` structure (from `m_octree_mg_3d`):**
+    -   Reads the grid hierarchy, domain parameters, and the source term from `mg%boxes(:)%cc(..., mg_irhs)`.
+    -   Modifies `mg%bc` by assigning `ghost_cells_free_bc` as the boundary condition handler for `mg_iphi`.
+    -   Invokes core multigrid solvers (`mg_fas_fmg`, `mg_fas_vcycle`) which operate on the `mg_t` structure.
+    -   The final solution is stored in `mg%boxes(:)%cc(..., mg_iphi)`.
+
+## Note on Compilation
+
+To use this `m_free_space` module (from the `single_module` directory), the following components must be compiled and linked:
+1.  The `m_octree_mg_3d` module. This is typically obtained by compiling `single_module/m_octree_mg.f90` with the preprocessor flag `-DNDIM=3`.
+2.  The `single_module/m_free_space.f90` file itself (which defines the `module m_free_space`).
+3.  The `poisson_solver` module. This requires compiling `poisson_3d_fft/poisson_solver.f90` along with all the source files it `include`s (e.g., `psolver_main.f90`, `build_kernel.f90`, `fft3d.f90`, etc.).
+4.  An MPI library.
+5.  (If XC support were enabled in `PSolver`, though it's hardcoded off here: ABINIT's XC library and its dependencies).
+
+## Usage Examples
+
+```fortran
+! Conceptual usage of the m_free_space module with m_octree_mg_3d
+
+program test_free_space_solver_single_module
+  use m_octree_mg_3d  ! The single-file 3D octree-mg library
+  use m_free_space    ! This module for free-space boundary conditions
+  use mpi             ! For MPI_Init, MPI_Finalize, etc.
+
+  implicit none
+
+  type(mg_t) :: mg_configuration
+  logical    :: is_new_rhs
+  real(dp)   :: fft_coarsening_factor
+  logical    :: use_fmg_solver
+  real(dp)   :: final_solver_residual
+  integer    :: mpi_error
+
+  ! 1. Initialize MPI Environment
+  call MPI_Init(mpi_error)
+  call mg_comm_init(mg_configuration) ! Initialize MPI info within mg_t
+
+  ! 2. Configure mg_configuration structure
+  !    (Set domain size, box size, operator_type=mg_laplacian, geometry_type=mg_cartesian etc.)
+  !    call setup_mg_grid_and_parameters(mg_configuration) ! Placeholder for detailed setup
+  mg_configuration%operator_type = mg_laplacian
+  mg_configuration%geometry_type = mg_cartesian
+
+  ! 3. Build the octree grid structure
+  !    call mg_build_rectangle(mg_configuration, ...) ! Placeholder
+
+  ! 4. Load balance the grid
+  !    call mg_load_balance(mg_configuration) ! Placeholder
+
+  ! 5. Allocate storage for grid data
+  !    call mg_allocate_storage(mg_configuration) ! Placeholder
+
+  ! 6. Define the source term (e.g., charge density)
+  !    This involves populating mg_configuration%boxes(:)%cc(..., mg_irhs)
+  !    call set_source_term(mg_configuration) ! Placeholder
+
+  ! 7. Set parameters for the free-space solver
+  is_new_rhs = .true.              ! True for the first solve or if RHS changes
+  fft_coarsening_factor = 0.1_dp ! FFT grid uses <= 10% of total unknowns
+  use_fmg_solver = .true.          ! Use FMG for the octree-mg part
+
+  ! 8. Call the free-space Poisson solver
+  !    This routine will internally use poisson_solver for the coarse grid
+  !    and then call m_octree_mg_3d routines (like mg_fas_fmg) for finer levels.
+  call mg_poisson_free_3d(mg_configuration, is_new_rhs, fft_coarsening_factor, &
+                           use_fmg_solver, max_res=final_solver_residual)
+
+  ! 9. The solution (potential phi) is now in mg_configuration%boxes(:)%cc(..., mg_iphi)
+  if (mg_configuration%my_rank == 0) then
+    print *, "Free-space Poisson solve complete."
+    print *, "Final residual from octree-mg solver:", final_solver_residual
+  end if
+
+  ! 10. Deallocate storage
+  !    call mg_deallocate_storage(mg_configuration) ! Placeholder
+
+  ! 11. Finalize MPI
+  call MPI_Finalize(mpi_error)
+
+end program test_free_space_solver_single_module
+```

--- a/docs/single_module/doc_single_module_overview.md
+++ b/docs/single_module/doc_single_module_overview.md
@@ -1,0 +1,67 @@
+# Overview of the `single_module` Directory
+
+## Overview
+
+The `single_module` directory within the `octree-mg` library distribution offers a convenient way to integrate the core functionalities of the library into other Fortran projects. Instead of managing multiple source files and module dependencies from the main `src/` directory, this directory provides options to include the entire library (with some considerations for the free-space Poisson solver) as a single Fortran module file. This approach can significantly simplify the build process for projects that utilize `octree-mg`.
+
+The primary mechanism involves a main source file, `m_octree_mg.f90`, which uses a C-preprocessor directive (`NDIM`) to generate dimension-specific code (1D, 2D, or 3D). Pre-generated versions for each dimension are also typically provided.
+
+## Key Files and Their Purpose
+
+-   **`m_octree_mg.f90`**:
+    -   This is the main, preprocessor-driven source file. It is designed to be compiled with a flag like `-DNDIM=1`, `-DNDIM=2`, or `-DNDIM=3`.
+    -   When compiled, it effectively concatenates all the core modules from the `src/` directory (e.g., `m_data_structures`, `m_build_tree`, `m_load_balance`, `m_ghost_cells`, `m_allocate_storage`, `m_restrict`, `m_communication`, `m_prolong`, `m_multigrid`, and the various operator modules like `m_laplacian`, `m_helmholtz`, etc.) into a single dimension-specific module.
+    -   The resulting Fortran module name will depend on the `NDIM` definition (e.g., `m_octree_mg_1d`, `m_octree_mg_2d`, `m_octree_mg_3d`).
+
+-   **`m_octree_mg_1d.f90`**:
+    -   A pre-generated single-file Fortran module for 1D simulations.
+    -   This is likely the output of compiling `single_module/m_octree_mg.f90` with `-DNDIM=1`.
+    -   It defines a Fortran module named `m_octree_mg_1d`.
+
+-   **`m_octree_mg_2d.f90`**:
+    -   A pre-generated single-file Fortran module for 2D simulations.
+    -   Likely the output of compiling `single_module/m_octree_mg.f90` with `-DNDIM=2`.
+    -   It defines a Fortran module named `m_octree_mg_2d`.
+
+-   **`m_octree_mg_3d.f90`**:
+    -   A pre-generated single-file Fortran module for 3D simulations.
+    -   Likely the output of compiling `single_module/m_octree_mg.f90` with `-DNDIM=3`.
+    -   It defines a Fortran module named `m_octree_mg_3d`.
+
+-   **`to_single_module.sh`**:
+    -   A shell script responsible for generating the dimension-specific single-file modules (`m_octree_mg_1d.f90`, `m_octree_mg_2d.f90`, `m_octree_mg_3d.f90`) from the main `m_octree_mg.f90` source file and, by extension, from the individual modules in the `src/` directory. It likely invokes the Fortran compiler with the appropriate preprocessor flags.
+
+-   **`m_free_space.f90`**:
+    -   This file, also present in the `single_module` directory (and originally in `src/`), provides the `m_free_space` module.
+    -   This module implements a specialized Poisson solver for 3D free-space (open) boundary conditions.
+    -   It is intended to be used alongside `m_octree_mg_3d.f90` if this specific boundary condition handling is required. It is separate because its primary dependency, the `Poisson_Solver` FFT library, is a more complex external dependency.
+
+## How to Use
+
+Developers wishing to integrate `octree-mg` into their projects using the single-module approach have two primary options:
+
+1.  **Use Pre-generated Files:**
+    -   Copy the appropriate dimension-specific file (`m_octree_mg_1d.f90`, `m_octree_mg_2d.f90`, or `m_octree_mg_3d.f90`) directly into their project's source directory.
+    -   Compile this file as part of their project.
+    -   In their own Fortran code, `use` the corresponding module (e.g., `use m_octree_mg_2d`).
+
+2.  **Compile `m_octree_mg.f90` Manually:**
+    -   Copy `single_module/m_octree_mg.f90` into their project.
+    -   Compile this file using their Fortran compiler, ensuring the C preprocessor is invoked and the `NDIM` macro is defined (e.g., `gfortran -cpp -DNDIM=3 m_octree_mg.f90 -c`).
+    -   The compiled module object file can then be linked, and the corresponding dimension-specific module (e.g., `m_octree_mg_3d`) can be `use`d.
+
+By `use`ing one of these generated modules (e.g., `use m_octree_mg_3d`), all the public entities (derived types like `mg_t`, subroutines like `mg_build_rectangle`, `mg_fas_fmg`, constants like `mg_iphi`) from the original individual `src/` modules become available to the user's code.
+
+## Note on `m_free_space.f90`
+
+-   If the specialized 3D free-space Poisson solver is required, the `single_module/m_free_space.f90` file should also be compiled into the project.
+-   The user's code would then also `use m_free_space`.
+-   The `m_free_space` module itself internally `use`s `m_octree_mg_3d` (when compiled as part of the single-module system or if that module is otherwise available), indicating it's designed to work with the 3D version of the core library.
+
+## Redundancy with `docs/src/` Documentation
+
+The detailed documentation for the individual components, data structures, and algorithms that are bundled into these single-module files (e.g., `m_octree_mg_1d.f90`, `m_octree_mg_2d.f90`, `m_octree_mg_3d.f90`) can be found in the `docs/src/` directory. The single-module files are primarily concatenations and preprocessor adaptations of these original source files. Therefore, for understanding the specifics of `type(mg_t)`, `mg_laplacian`, `mg_multigrid`, etc., users should refer to the respective `doc_m_*.f90.md` files.
+
+## Exclusion of `poisson_3d_fft`
+
+It is important to note that the `poisson_3d_fft` library, which is a dependency for the `m_free_space` module, is **not** directly bundled into the `m_octree_mg_Xd.f90` single-module files. If `m_free_space` is used, the `poisson_3d_fft` library (and its own dependencies, like an MPI library and potentially ABINIT's XC routines if XC support is enabled) must be compiled and linked separately. The `single_module/m_free_space.f90` file only contains the interface code to `poisson_3d_fft`, not the solver itself.

--- a/docs/src/doc_m_ahelmholtz.f90.md
+++ b/docs/src/doc_m_ahelmholtz.f90.md
@@ -1,0 +1,75 @@
+# `m_ahelmholtz.f90`
+
+## Overview
+
+The module `m_ahelmholtz` implements multigrid procedures for solving an anisotropic Helmholtz equation of the form: `div(D grad(phi)) - lambda*phi = f`. In this equation, `D` represents a spatially varying anisotropic diffusion coefficient (with components in each spatial direction), `lambda` is a scalar constant, `phi` is the unknown field, and `f` is the source term. This module is a core component of the `m_octree_mg` octree-based multigrid library.
+
+## Key Components
+
+### Modules
+
+- **`m_ahelmholtz`:** This module encapsulates all the necessary subroutines and variables for defining and solving the anisotropic Helmholtz equation using the multigrid framework. It handles the setup of specific operator and smoother routines and manages the `lambda` parameter.
+
+### Functions/Subroutines
+
+- **`ahelmholtz_set_methods(mg)`:**
+  - **Description:** Configures the multigrid structure (`mg`) with the appropriate function pointers for the anisotropic Helmholtz operator (`mg%box_op => box_ahelmh`) and the Gauss-Seidel smoother (`mg%box_smoother => box_gs_ahelmh`). It also sets up Neumann zero boundary conditions for the components of the anisotropic coefficient `D` (stored in `mg%cc` at indices `mg_iveps1`, `mg_iveps2`, `mg_iveps3`), as these are required in ghost cells.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure to be configured.
+- **`ahelmholtz_set_lambda(lambda)`:**
+  - **Description:** Sets the global scalar value for `lambda` used in the Helmholtz equation. It enforces that `lambda` must be non-negative.
+  - **Arguments:**
+    - `lambda (real(dp), intent(in))`: The value for the Helmholtz coefficient `lambda`.
+- **`box_gs_ahelmh(mg, id, nc, redblack_cntr)`:** (Private)
+  - **Description:** Performs Gauss-Seidel relaxation (optionally red-black ordered) on a specified computational box (`id`) within the multigrid hierarchy. This routine is used as a smoother to reduce high-frequency errors.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `id (integer, intent(in))`: The identifier of the box to operate on.
+    - `nc (integer, intent(in))`: The size of the computational box (number of cells in each direction).
+    - `redblack_cntr (integer, intent(in))`: A counter used to determine the cell parity in red-black Gauss-Seidel.
+- **`box_ahelmh(mg, id, nc, i_out)`:** (Private)
+  - **Description:** Applies the discretized anisotropic Helmholtz operator (`L(phi) = div(D grad(phi)) - lambda*phi`) to the variable `phi` (stored at `mg_iphi` index) within a specified computational box (`id`). The result is stored in the `i_out` component of the box's cell-centered data array (`mg%boxes(id)%cc`).
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `id (integer, intent(in))`: The identifier of the box to operate on.
+    - `nc (integer, intent(in))`: The size of the computational box.
+    - `i_out (integer, intent(in))`: The index within the `cc` array where the output of the operator will be stored.
+
+## Important Variables/Constants
+
+- **`ahelmholtz_lambda (real(dp), public, protected)`:** This module-level variable stores the scalar `lambda` (must be ≥ 0) for the Helmholtz equation: `div(D grad(phi)) - lambda*phi = f`. It is set by the `ahelmholtz_set_lambda` subroutine.
+
+## Usage Examples
+
+Usage of this module is typically indirect, through the higher-level multigrid solver routines provided by the `m_octree_mg` library. However, the setup process involves:
+
+```fortran
+! Conceptual example:
+! Assume 'mg_object' is a properly initialized 'mg_t' type from m_data_structures,
+! and 'desired_lambda' is a real(dp) variable holding the lambda value.
+
+! 1. Set the lambda for the Helmholtz equation:
+call ahelmholtz_set_lambda(desired_lambda)
+
+! 2. Configure the multigrid methods for the Helmholtz solver:
+! This assigns box_ahelmh to mg_object%box_op and
+! box_gs_ahelmh to mg_object%box_smoother.
+call ahelmholtz_set_methods(mg_object)
+
+! 3. Perform multigrid cycles (e.g., V-cycle, FMG):
+! These cycles will internally use the operator (mg_object%box_op) and
+! smoother (mg_object%box_smoother) configured above.
+! call mg_solve(mg_object, ...) ! (Actual solver call might vary)
+```
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - `m_data_structures`: This module heavily relies on `m_data_structures` for core data types like `mg_t` (the main multigrid structure), `dp` (double precision kind), `NDIM` (number of dimensions), and various integer constants defining indices for variables within cell-centered data arrays (e.g., `mg_iphi` for the solution field, `mg_irhs` for the right-hand side, `mg_iveps1`, `mg_iveps2`, `mg_iveps3` for the components of the anisotropic coefficient `D`). It also uses defined constants for boundary condition types (e.g., `mg_bc_neumann`).
+- **External Libraries:**
+  - `cpp_macros.h`: This is a C-preprocessor include file, likely containing project-specific macros used for conditional compilation (e.g., `#if NDIM == ...`). It's not an external library in the typical sense but a build system dependency.
+- **Interactions with Other Components:**
+  - The `m_ahelmholtz` module is integral to the `m_octree_mg` library. The `ahelmholtz_set_methods` subroutine directly modifies the `mg_t` object by assigning its function pointers (`box_op`, `box_smoother`) to the local `box_ahelmh` and `box_gs_ahelmh` subroutines, respectively. These function pointers are then invoked by the generic multigrid cycling routines (e.g., V-cycle, W-cycle, FMG) within the `m_octree_mg` framework.
+  - The solver operates on `box` data structures, which are fundamental components of the octree-based grid managed by `m_octree_mg`.
+  - The module requires that the anisotropic coefficients `D` are stored in the cell-centered data arrays of each box (at indices `mg_iveps1`, etc.) and sets Neumann boundary conditions for these coefficients to ensure correct behavior at box boundaries during operator application and smoothing.
+```

--- a/docs/src/doc_m_allocate_storage.f90.md
+++ b/docs/src/doc_m_allocate_storage.f90.md
@@ -1,0 +1,94 @@
+# `m_allocate_storage.f90`
+
+## Overview
+
+The `m_allocate_storage` module serves as the primary memory management unit within the `m_octree_mg` (Octree Multigrid) library. It is responsible for the dynamic allocation and deallocation of memory for essential data structures, particularly for the cell-centered data within computational grid boxes (`mg%boxes(id)%cc`), arrays describing the multigrid level properties (`mg%lvls`), and the communication buffers (`mg%buf`) required for parallel processing tasks like ghost cell exchange, restriction, and prolongation.
+
+## Key Components
+
+### Modules
+
+- **`m_allocate_storage`:** This module provides the public interface for allocating and freeing memory associated with a multigrid (`mg_t`) object.
+
+### Functions/Subroutines
+
+- **`mg_allocate_storage(mg)`:**
+  - **Description:** This subroutine allocates memory for the primary data arrays once the multigrid tree structure (`mg%tree_created`) has been established. Specifically, it allocates:
+    1.  The cell-centered data array `cc` for each locally owned computational box (`mg%boxes(id)`) on each multigrid level. The dimensions of `cc` depend on the box size (`nc`), the number of dimensions (`NDIM` via `DTIMES` macro), and the total number of variables (`mg_num_vars + mg%n_extra_vars`). Initial values are set to zero.
+    2.  Communication buffers (`mg%buf`) for each potential MPI rank. The size of these buffers is determined by querying routines from `m_ghost_cells`, `m_restrict`, and `m_prolong` modules to ensure they are large enough for the respective communication patterns.
+    It sets `mg%is_allocated` to true upon successful completion.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure for which storage is to be allocated.
+- **`mg_deallocate_storage(mg)`:**
+  - **Description:** This subroutine deallocates all dynamically allocated memory associated with the provided multigrid structure (`mg`). This includes:
+    1.  The `cc` data arrays within all `mg%boxes`.
+    2.  The send/receive buffers and index arrays within `mg%buf`.
+    3.  Various arrays associated with each multigrid level stored in `mg%lvls(lvl)%...` (e.g., `ids`, `leaves`, `parents`, `my_ids`).
+    4.  Communication partner lists for restriction, prolongation, and ghost cells.
+    It also resets `mg%is_allocated` to `false` and `mg%n_boxes` to 0.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure whose storage is to be deallocated.
+
+## Important Variables/Constants
+
+This module primarily acts on variables defined within the `mg_t` type (from `m_data_structures`). Key data members from `mg_t` that influence allocation include:
+
+- **`mg%box_size_lvl(lvl)`:** An array determining the number of cells (`nc`) per side for boxes at a given multigrid level `lvl`.
+- **`mg_num_vars`:** A constant (from `m_data_structures`) specifying the base number of physical variables stored per cell.
+- **`mg%n_extra_vars`:** A variable within `mg_t` allowing for additional user-defined variables per cell.
+- **`mg%n_cpu`:** The number of MPI processes, used for sizing communication buffer arrays.
+- **`mg%lowest_lvl`, `mg%highest_lvl`:** Define the range of multigrid levels to allocate.
+- **`mg%lvls(lvl)%my_ids`:** An array of box IDs owned by the current process at a given level, for which `cc` data needs to be allocated.
+
+The actual sizes of communication buffers are determined by functions imported from `m_ghost_cells`, `m_restrict`, and `m_prolong`.
+
+## Usage Examples
+
+The subroutines in this module are typically called after the basic multigrid hierarchy and box distribution have been determined, and before numerical operations begin. Conversely, deallocation occurs when the multigrid structure is no longer needed.
+
+```fortran
+! Conceptual example of allocation and deallocation:
+
+! Assume 'my_mg_structure' is a variable of type(mg_t)
+! and its tree (box hierarchy, levels, etc.) has been created.
+! For example, after 'call mg_create_tree(my_mg_structure, ...)'
+
+! Before performing operations, allocate storage:
+if (my_mg_structure%tree_created .and. .not. my_mg_structure%is_allocated) then
+    call mg_allocate_storage(my_mg_structure)
+    print *, "Storage allocated."
+else
+    if (.not. my_mg_structure%tree_created) print *, "Tree not created yet!"
+    if (my_mg_structure%is_allocated) print *, "Storage already allocated!"
+end if
+
+! ...
+! Perform multigrid computations using the allocated mg%boxes(id)%cc arrays
+! and communication buffers mg%buf.
+! ...
+
+! When finished, deallocate the storage:
+if (my_mg_structure%is_allocated) then
+    call mg_deallocate_storage(my_mg_structure)
+    print *, "Storage deallocated."
+else
+    print *, "Storage was not allocated or already deallocated."
+end if
+
+```
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** This is a fundamental dependency. `m_allocate_storage` extensively uses and manipulates the `mg_t` derived type and its members (e.g., `boxes`, `lvls`, `buf`, `is_allocated`, `tree_created`, `box_size_lvl`, `mg_num_vars`, `n_extra_vars`, `phi_bc_data_stored`, `n_boxes`). The `DTIMES` macro, likely defined to handle array dimensioning based on `NDIM`, also originates from or is used in conjunction with this module.
+  - **`m_ghost_cells` (via `mg_ghost_cell_buffer_size`):** Called by `mg_allocate_storage` to determine the required size for ghost cell communication buffers.
+  - **`m_restrict` (via `mg_restrict_buffer_size`):** Called by `mg_allocate_storage` to determine the required size for restriction operation communication buffers.
+  - **`m_prolong` (via `mg_prolong_buffer_size`):** Called by `mg_allocate_storage` to determine the required size for prolongation operation communication buffers.
+- **External Libraries:**
+  - **`cpp_macros.h`:** This preprocessor include is used, likely for the `DTIMES` macro which appears to be used for setting array bounds based on the number of spatial dimensions (`NDIM`).
+- **Interactions with Other Components:**
+  - **Tree Construction Modules (e.g., `m_tree_build` - assumed):** Modules responsible for creating the multigrid hierarchy (`mg%tree_created = .true.`) must be called before `mg_allocate_storage`.
+  - **Parallel Communication Modules (e.g., `m_mpi_common`, `m_ghost_cells`, `m_restrict`, `m_prolong`):** These modules will utilize the communication buffers (`mg%buf`) allocated by `mg_allocate_storage`.
+  - **Solver and Operator Modules (e.g., `m_ahelmholtz`, `m_poisson`):** These modules operate on the `mg%boxes(id)%cc` data arrays that are allocated by `mg_allocate_storage`.
+  - **Initialization/Finalization routines:** The main program or higher-level control modules would invoke `mg_allocate_storage` during setup and `mg_deallocate_storage` during cleanup.
+```

--- a/docs/src/doc_m_build_tree.f90.md
+++ b/docs/src/doc_m_build_tree.f90.md
@@ -1,0 +1,132 @@
+# `m_build_tree.f90`
+
+## Overview
+
+The `m_build_tree` module is a cornerstone of the `m_octree_mg` library, tasked with the construction and structural definition of the hierarchical grid. This grid is typically a quadtree in two dimensions or an octree in three dimensions. The module handles the logic for creating the initial coarse grid based on specified domain parameters and then recursively building finer grid levels. This process involves instantiating box structures (nodes in the tree), defining their properties (level, spatial index, physical coordinates), establishing parent-child relationships between boxes at different levels, and setting up initial neighbor connectivity.
+
+## Key Components
+
+### Modules
+
+- **`m_build_tree`:** This module encapsulates all subroutines necessary for the initial generation and hierarchical organization of the multigrid tree structure.
+
+### Functions/Subroutines
+
+- **`mg_build_rectangle(mg, domain_size, box_size, dx, r_min, periodic, n_finer)`:**
+  - **Description:** This is the main public subroutine for constructing the complete multi-level grid hierarchy. It starts by defining the properties of the base level (level 1, typically the finest regular grid) such as grid spacing (`dr`), box size, and domain size. It then determines the parameters for coarser levels by either doubling the grid spacing or halving the number of boxes per dimension, until a specified coarsest grid criterion (`mg%coarsest_grid`) is met. It also defines metadata for finer levels if applicable. The subroutine allocates the main `mg%boxes` array to hold all box structures. It then explicitly creates all boxes for the determined `mg%lowest_lvl`, setting their geometric properties, initial neighbor information (handling periodic and physical boundaries), and parent/child links (initially `mg_no_box`). Subsequently, it iteratively calls `mg_add_children` (or `add_single_child` for specific coarsening strategies) to populate finer levels and uses helper subroutines (`mg_set_leaves_parents`, `mg_set_next_level_ids`, `mg_set_neighbors_lvl`) to complete the tree structure by identifying parent/leaf nodes at each level and ensuring full neighbor connectivity. Finally, it marks the tree as created (`mg%tree_created = .true.`).
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The main multigrid data structure to be populated.
+    - `domain_size (integer(NDIM), intent(in))`: Total number of cells in each dimension for the base level.
+    - `box_size (integer, intent(in))`: Number of cells per side for each box at the base level.
+    - `dx (real(dp)(NDIM), intent(in))`: Grid spacing in each dimension at the base level.
+    - `r_min (real(dp)(NDIM), intent(in))`: Physical coordinate of the domain's minimum corner.
+    - `periodic (logical(NDIM), intent(in))`: Flags indicating periodicity in each dimension.
+    - `n_finer (integer, intent(in))`: Number of additional box structures to allocate space for, anticipating future refinements.
+
+- **`mg_add_children(mg, id)`:**
+  - **Description:** Creates a full set of child boxes (e.g., 4 for `NDIM=2`, 8 for `NDIM=3`) for a given parent box `id`. It increments `mg%n_boxes`, assigns IDs to the new children, and links them to the parent `id`. Properties for each child (rank, logical index `ix`, level, parent pointer, initial neighbors, physical minimum `r_min`, and grid spacing `dr`) are derived from the parent box and the grid hierarchy. Boundary conditions for children facing the domain edge are set based on the parent's boundary conditions.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `id (integer, intent(in))`: The ID of the parent box to which children will be added.
+
+- **`mg_set_leaves_parents(boxes, level)`:**
+  - **Description:** Scans all boxes listed in `level%ids`. For each box, it checks if it has children. If it does, the box ID is added to `level%parents`. If it does not, the ID is added to `level%leaves`. This populates lists of parent nodes and terminal (leaf) nodes at a specific grid level.
+  - **Arguments:**
+    - `boxes (type(mg_box_t), intent(in))`: The array of all box structures.
+    - `level (type(mg_lvl_t), intent(inout))`: The level structure whose `parents` and `leaves` lists are to be populated.
+
+- **`mg_set_next_level_ids(mg, lvl)`:**
+  - **Description:** Populates the `mg%lvls(lvl+1)%ids` array. It collects all the children from the parent boxes found in `mg%lvls(lvl)%parents` and lists their IDs, effectively defining all boxes that exist at level `lvl+1`.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `lvl (integer, intent(in))`: The current level whose parents' children will form the next level.
+
+- **`mg_set_refinement_boundaries(boxes, level)`:**
+  - **Description:** Identifies leaf boxes on a given `level` that are adjacent to coarser boxes (i.e., a neighbor of the leaf box is a parent box on the same level). Such leaf boxes form the finer side of a refinement boundary. Their IDs are stored in `level%ref_bnds`.
+  - **Arguments:**
+    - `boxes (type(mg_box_t), intent(in))`: The array of all box structures.
+    - `level (type(mg_lvl_t), intent(inout))`: The level structure for which refinement boundaries are identified.
+
+- **`mg_set_neighbors_lvl(mg, lvl)`:**
+  - **Description:** Ensures all boxes on a specified `lvl` have their neighbor information correctly and fully established. It iterates through `mg%lvls(lvl)%ids` and calls the private `set_neighbs` routine for each box.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `lvl (integer, intent(in))`: The level for which neighbor information is to be finalized.
+
+### Private Helper Subroutines (Notable)
+- `add_single_child(mg, id, n_boxes_lvl)`: Creates a single child for a box, used in specific scenarios where the effective grid resolution changes between levels differently than the standard refinement.
+- `set_neighbs(boxes, id)`: Orchestrates neighbor finding for a single box `id` by calling `find_neighb` for each neighbor direction if not already set.
+- `find_neighb(boxes, id, nb)`: A key routine that determines the ID of a neighbor for box `id` in direction `nb`. It might navigate up to the parent level and across to the parent's neighbor, then down to the appropriate child on the adjacent branch of the tree.
+
+## Important Variables/Constants
+
+The tree construction process is heavily influenced by:
+- Inputs to `mg_build_rectangle`: `domain_size`, `box_size`, `dx`, `r_min`, `periodic`, `n_finer`.
+- Parameters within the `mg_t` structure (often set by `mg_init_default` or other setup routines):
+  - `mg%coarsest_grid`: Defines a limit on how coarse the grid hierarchy can be.
+  - `mg%smoother_type`: Can influence coarsening strategy, especially `mg_smoother_gs`.
+- Constants from `m_data_structures`:
+  - `NDIM`: Number of spatial dimensions.
+  - `mg_lvl_lo`, `mg_lvl_hi`: Bounds for multigrid level indexing.
+  - `mg_no_box`, `mg_physical_boundary`: Special values for box IDs/neighbor links.
+  - `mg_num_children`, `mg_num_neighbors`: Geometric constants (2/4 in 1D, 4/8 in 2D, 8/26 in 3D, though neighbors are typically face-neighbors).
+  - Various `mg_child_...` arrays/functions: Provide geometric relationships between parent and child boxes.
+
+## Usage Examples
+
+```fortran
+! Conceptual example of building the initial tree:
+use m_data_structures
+use m_build_tree
+! Potentially use m_default_settings to initialize mg_t
+! use m_default_settings, only: mg_init_default
+
+type(mg_t) :: my_grid
+integer    :: domain_cells(2), cells_per_box_side
+real(dp)   :: cell_spacing(2), domain_origin(2)
+logical    :: domain_is_periodic(2)
+integer    :: space_for_future_boxes
+
+! call mg_init_default(my_grid) ! Initialize my_grid with library defaults
+
+! Define parameters for a 2D grid
+domain_cells         = [256, 256]  ! Total cells in underlying finest grid
+cells_per_box_side   = 32          ! Cells per side for each box
+cell_spacing         = [1.0_dp/256.0_dp, 1.0_dp/256.0_dp]
+domain_origin        = [0.0_dp, 0.0_dp]
+domain_is_periodic   = [.false., .false.]
+space_for_future_boxes = 2000 ! Buffer for boxes added by dynamic refinement
+
+! Construct the tree
+call mg_build_rectangle(my_grid, domain_cells, cells_per_box_side, &
+                         cell_spacing, domain_origin, domain_is_periodic, &
+                         space_for_future_boxes)
+
+if (my_grid%tree_created) then
+  print *, "Octree/Quadtree structure built. Total boxes created:", my_grid%n_boxes
+  print *, "Lowest level:", my_grid%lowest_lvl, "Highest level:", my_grid%highest_lvl
+  ! Next steps typically include:
+  ! - Distributing boxes among MPI processes (m_load_balance)
+  ! - Allocating memory for cell data (m_allocate_storage)
+else
+  print *, "Failed to build the tree structure."
+end if
+
+! Note: Direct public subroutines for dynamic refinement (refine_box) or
+! coarsening (coarsen_box) are not part of this specific module.
+! However, mg_add_children is a building block that would be used by such features.
+```
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** This is the most critical dependency. The module extensively uses and manipulates the `mg_t`, `mg_box_t`, and `mg_lvl_t` derived types and their numerous members (e.g., `boxes`, `lvls`, `n_boxes`, `tree_created`, `ix`, `lvl`, `parent`, `children`, `neighbors`, `r_min`, `dr`, `ids`, `leaves`, `parents`, `ref_bnds`). It also relies on various constants defined in `m_data_structures` that relate to grid geometry and special marker values.
+- **External Libraries:**
+  - **`cpp_macros.h`:** Used for C-preprocessor macros such as `KJI_DO_VEC` and `CLOSE_DO`, which are likely shorthand for multi-dimensional loop constructs.
+- **Interactions with Other Components:**
+  - **`m_allocate_storage`:** After `mg_build_rectangle` successfully executes (setting `mg%tree_created = .true.`), the `m_allocate_storage` module is typically called to allocate memory for the actual cell-centered data (`cc` arrays) within each box (`mg%boxes(id)%cc`) and for communication buffers. The `mg_build_rectangle` subroutine itself allocates the `mg%boxes` array (array of structures).
+  - **`m_load_balance`:** The initial tree built by `mg_build_rectangle` assigns all boxes to rank 0. A load balancing module (`m_load_balance`) is essential in a parallel environment to distribute these boxes among available MPI processes. Dynamic tree modifications (refinement/coarsening) would also likely trigger load balancing.
+  - **Initialization Routines (e.g., `m_default_settings`):** Modules that set default values or overall parameters for the `mg_t` type are usually called before `mg_build_rectangle`.
+  - **Boundary Condition Modules:** The `periodic` flags passed to `mg_build_rectangle` and the assignment of `mg_physical_boundary` to neighbor links directly influence how boundary conditions are identified and applied by other parts of the solver.
+  - **Refinement/Coarsening Modules:** While not fully exposed as public interfaces in this file, any higher-level modules that implement adaptive mesh refinement (AMR) would use routines like `mg_add_children` (for refinement) and would need mechanisms to remove or deactivate boxes (for coarsening), which would modify the tree structure created by this module.
+```

--- a/docs/src/doc_m_communication.f90.md
+++ b/docs/src/doc_m_communication.f90.md
@@ -1,0 +1,122 @@
+# `m_communication.f90`
+
+## Overview
+
+The `m_communication` module is central to enabling parallel execution of the `m_octree_mg` library. It encapsulates the necessary Message Passing Interface (MPI) functionalities to facilitate data exchange between different MPI processes. This module provides the mechanisms for common parallel tasks such as updating ghost cell regions (halo data) around local subdomains and transferring data segments during distributed multigrid operations like restriction and prolongation. While this module provides the generic transfer capability, specific data packing and unpacking for such operations are typically handled by other modules that utilize these communication routines.
+
+## Key Components
+
+### Modules
+
+- **`m_communication`:** This module contains the subroutines and MPI interactions for inter-process data transfer.
+
+### Functions/Subroutines
+
+- **`mg_comm_init(mg, comm)`:**
+  - **Description:** Initializes the MPI environment if it has not been initialized already. It then populates the `mg_t` data structure with essential MPI information: the MPI communicator (`mg%comm`), the rank of the current process (`mg%my_rank`), and the total number of processes (`mg%n_cpu`) in the communicator. An optional `comm` argument allows the user to specify a particular MPI communicator; if omitted, `MPI_COMM_WORLD` is used by default.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The main multigrid data structure where MPI information will be stored.
+    - `comm (integer, intent(in), optional)`: An existing MPI communicator to be used. Defaults to `MPI_COMM_WORLD`.
+
+- **`sort_and_transfer_buffers(mg, dsize)`:**
+  - **Description:** This is the core routine for performing bulk data exchange between MPI processes. For each other process `i`:
+    1. If data is queued for sending to process `i` (i.e., `mg%buf(i)%i_send > 0`), the send buffer `mg%buf(i)%send` is first sorted by the `sort_sendbuf` routine based on `mg%buf(i)%ix`. An asynchronous MPI send (`MPI_ISEND`) is then posted.
+    2. If data is expected from process `i` (i.e., `mg%buf(i)%i_recv > 0`), an asynchronous MPI receive (`MPI_IRECV`) is posted for `mg%buf(i)%recv`.
+    After initiating all non-blocking send and receive operations, the subroutine waits for all receive operations to complete, followed by waiting for all send operations to complete, using `MPI_WAITALL`. The MPI tag for these operations is hardcoded to `0`.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure containing the communication buffers (`mg%buf`).
+    - `dsize (integer, intent(in))`: The size (number of `real(dp)` elements) of each logical item within the send/receive buffers. This is used by `sort_sendbuf` to correctly permute data.
+
+### Private Helper Subroutines
+
+- **`sort_sendbuf(gc, dsize)`:**
+  - **Description:** Sorts the data in the send buffer `gc%send` according to the order specified by the `gc%ix` array (which contains original indices or keys for sorting). This is crucial if data items were added to the send buffer in an arbitrary order but need to be received in a specific, agreed-upon order. The sorting is performed out-of-place using a copy, and the `mrgrnk` routine (presumably a merge-rank sort algorithm from module `m_mrgrnk`) is used to obtain the permutation indices for reordering both `gc%send` and `gc%ix`.
+  - **Arguments:**
+    - `gc (type(mg_buf_t), intent(inout))`: The communication buffer structure for a specific partner rank, containing `send`, `ix`, and `i_send`, `i_ix` counters.
+    - `dsize (integer, intent(in))`: The size of each data item in `gc%send` in terms of `real(dp)` elements.
+
+## Important Variables/Constants
+
+- **From `mg_t` (populated by `mg_comm_init` or used by routines):**
+  - `mg%comm (integer)`: Stores the MPI communicator handle.
+  - `mg%my_rank (integer)`: Rank of the current MPI process.
+  - `mg%n_cpu (integer)`: Total number of MPI processes.
+  - `mg%buf (array of type(mg_buf_t))`: Array of buffer structures, one for each MPI rank, used for sending and receiving data.
+- **Standard MPI Constants (used from `mpi` module):**
+  - `MPI_COMM_WORLD`: Default MPI communicator.
+  - `MPI_DOUBLE`: MPI datatype for `real(dp)` variables.
+  - `MPI_STATUSES_IGNORE`: Used in `MPI_WAITALL` when detailed status of each operation is not needed.
+  - MPI error codes (`ierr`).
+- **Communication Tag:** A default tag of `0` is used for messages in `sort_and_transfer_buffers`.
+
+## Usage Examples
+
+```fortran
+! Conceptual example: Initialize MPI and perform a generic data exchange.
+
+use m_data_structures
+use m_communication
+! Assuming 'mpi' module is available for MPI constants if not re-exported.
+
+type(mg_t) :: my_multigrid_setup
+integer    :: items_per_buffer_element
+
+! 1. Initialize communication aspects of the multigrid setup
+! This is typically done once at the beginning of a parallel run.
+call mg_comm_init(my_multigrid_setup) ! Uses MPI_COMM_WORLD by default.
+                                     ! Alternatively, pass a specific communicator:
+                                     ! call mg_comm_init(my_multigrid_setup, my_custom_comm)
+
+! Print rank for verification
+print *, "Process ", my_multigrid_setup%my_rank, " of ", my_multigrid_setup%n_cpu, " initialized."
+
+if (my_multigrid_setup%n_cpu > 1) then
+    ! 2. Prepare data for sending and specify expected receive counts.
+    ! This part is typically handled by other modules (e.g., m_ghost_cells, m_restrict).
+    ! For example, a hypothetical routine in another module might:
+    ! call prepare_data_for_exchange(my_multigrid_setup, items_per_buffer_element)
+    ! This routine would:
+    !   - Loop through destination ranks `dest_rank = 0, my_multigrid_setup%n_cpu - 1`.
+    !   - Fill `my_multigrid_setup%buf(dest_rank)%send(1:count_send)` with data.
+    !   - Fill `my_multigrid_setup%buf(dest_rank)%ix(1:count_ix)` with sorting keys.
+    !   - Set `my_multigrid_setup%buf(dest_rank)%i_send = count_send`.
+    !   - Set `my_multigrid_setup%buf(dest_rank)%i_ix = count_ix`.
+    !   - Set `my_multigrid_setup%buf(source_rank)%i_recv = count_recv` for expected data.
+
+    items_per_buffer_element = 1 ! Or mg_num_vars, etc., depending on what's being sent
+
+    ! 3. Execute the sorted data transfer.
+    ! Data in send buffers is sorted, then exchanged using MPI_Isend/Irecv, followed by MPI_Waitall.
+    call sort_and_transfer_buffers(my_multigrid_setup, items_per_buffer_element)
+
+    ! 4. Process the received data.
+    ! Again, this would be handled by the modules that initiated the exchange.
+    ! For example:
+    ! call unpack_and_use_exchanged_data(my_multigrid_setup, items_per_buffer_element)
+    ! This routine would read from `my_multigrid_setup%buf(source_rank)%recv(1:count_recv)`.
+
+    print *, "Process ", my_multigrid_setup%my_rank, ": Buffer transfer complete."
+else
+    print *, "Single process run, no MPI communication performed by sort_and_transfer_buffers."
+end if
+
+! MPI_Finalize would be called elsewhere, typically at the very end of the program.
+```
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Absolutely essential. This module defines `type(mg_t)` (which stores MPI handles like `comm`, `my_rank`, `n_cpu`, and the array of communication buffers `buf`) and `type(mg_buf_t)` (which defines the structure of individual send/receive buffers: `send`, `recv`, `ix` arrays, and their respective counters `i_send`, `i_recv`, `i_ix`).
+  - **`m_mrgrnk` (via `sort_sendbuf`):** This module provides the `mrgrnk` subroutine, which is used to perform a sort (likely a merge-rank sort) of indices to reorder the send buffer before transmission. This ensures data arrives in the order expected by the receiver.
+- **External Libraries:**
+  - **`mpi`:** The entire module is a wrapper and utility layer over the MPI library. All core communication operations (`MPI_Init`, `MPI_Comm_rank`, `MPI_Isend`, `MPI_Irecv`, `MPI_Waitall`, etc.) are direct calls to the MPI library.
+- **Interactions with Other Components:**
+  - **Program Initialization:** `mg_comm_init` is called during the initial setup phase of the simulation to prepare the MPI environment and store necessary MPI-related information in the `mg_t` structure.
+  - **Data Preparation Modules (e.g., `m_ghost_cells`, `m_restrict`, `m_prolong`):** These modules are responsible for identifying what data needs to be exchanged. They would:
+    1.  Populate the `send` array and `ix` array within `mg%buf(target_rank)` for each process that needs to receive data.
+    2.  Set the `i_send` and `i_ix` counters for outgoing messages.
+    3.  Set the `i_recv` counter for expected incoming messages.
+    Once data is packed into buffers, these modules would then call `sort_and_transfer_buffers` to execute the physical data transfer.
+  - **Data Consumption Modules:** After `sort_and_transfer_buffers` returns, the same modules (or related ones) would unpack the data from the `recv` array of `mg%buf(source_rank)` and use it for their intended purpose (e.g., updating ghost cell values in the local grid, providing data for restriction/prolongation calculations).
+  - **Numerical Kernels (e.g., in `m_ahelmholtz`, `m_poisson`):** Any stencil-based computations or other operations that depend on data from neighboring domains rely on the ghost cells being correctly and timely updated. The communication facilitated by this module is thus a prerequisite for the correctness of these numerical operations in a parallel setting.
+```

--- a/docs/src/doc_m_data_structures.f90.md
+++ b/docs/src/doc_m_data_structures.f90.md
@@ -1,0 +1,247 @@
+# `m_data_structures.f90`
+
+## Overview
+
+The `m_data_structures` module is arguably the most critical and foundational module within the `m_octree_mg` library. It serves as the central repository for all primary data structure definitions (Fortran derived types) and named constants. These definitions provide the common language and data representation used by virtually all other modules in the library to describe the multigrid hierarchy, individual grid levels, computational boxes (cells/nodes), communication buffers, boundary conditions, and various control parameters. Understanding this module is key to understanding how data is organized and manipulated throughout the octree-mg framework.
+
+## Key Components
+
+### Modules
+
+- **`m_data_structures`:** Defines derived types, named constants, abstract interfaces for procedure pointers, and some utility functions related to these data structures.
+
+### Derived Type Definitions
+
+- **`mg_lvl_t`**: Represents data associated with a specific refinement level in the multigrid hierarchy.
+  - `leaves (integer, allocatable, :)`: IDs of boxes on this level that are leaves (have no children).
+  - `parents (integer, allocatable, :)`: IDs of boxes on this level that are parents (have children).
+  - `ref_bnds (integer, allocatable, :)`: IDs of leaf boxes on this level that are adjacent to coarser boxes (refinement boundaries).
+  - `ids (integer, allocatable, :)`: All box IDs belonging to this level across all processes.
+  - `my_leaves (integer, allocatable, :)`: IDs of leaf boxes on this level owned by the current MPI process.
+  - `my_parents (integer, allocatable, :)`: IDs of parent boxes on this level owned by the current MPI process.
+  - `my_ref_bnds (integer, allocatable, :)`: IDs of refinement boundary boxes on this level owned by the current MPI process.
+  - `my_ids (integer, allocatable, :)`: All box IDs on this level owned by the current MPI process.
+
+- **`mg_box_t`**: Represents a single computational box (a node in the octree/quadtree).
+  - `rank (integer)`: The MPI rank of the process that owns this box.
+  - `id (integer)`: Unique identifier for this box (typically its index in the global `mg%boxes(:)` array).
+  - `lvl (integer)`: The refinement level this box belongs to.
+  - `ix(NDIM) (integer)`: Logical spatial index of this box within its level (e.g., `[i,j,k]`).
+  - `parent (integer)`: ID of the parent box (or `mg_no_box`).
+  - `children(2**NDIM) (integer)`: IDs of child boxes (or `mg_no_box`). `NDIM` is resolved by preprocessor.
+  - `neighbors(2*NDIM) (integer)`: IDs of face-neighboring boxes (or `mg_no_box`, `mg_physical_boundary`). `NDIM` is resolved by preprocessor.
+  - `r_min(NDIM) (real(dp))`: Physical coordinates of the minimum corner of this box.
+  - `dr(NDIM) (real(dp))`: Grid spacing (cell size) within this box.
+  - `cc (real(dp), allocatable, DTIMES(:), :)`: Cell-centered data array. Dimensions depend on `NDIM` (e.g., `(0:nc+1, 0:nc+1, 0:nc+1, mg_num_vars + n_extra_vars)` for 3D including ghost cells). The `DTIMES(:)` macro likely handles the spatial dimensions. The second dimension indexes different variables (solution, RHS, etc.).
+
+- **`mg_buf_t`**: Represents communication buffers used for MPI data exchange, typically one per communicating pair of processes.
+  - `i_send (integer)`: Current number of elements in the `send` buffer.
+  - `i_recv (integer)`: Current number of elements in the `recv` buffer.
+  - `i_ix (integer)`: Current number of elements in the `ix` (index/sorting key) array.
+  - `ix (integer, allocatable, :)`: Array of indices or keys used for sorting data in the `send` buffer before transmission.
+  - `send (real(dp), allocatable, :)`: Buffer for outgoing data.
+  - `recv (real(dp), allocatable, :)`: Buffer for incoming data.
+
+- **`mg_comm_t`**: Used to store information about communication patterns for specific operations (restriction, prolongation, ghost cells).
+  - `n_send (integer, allocatable, :, :)`: Number of items to send to other processes.
+  - `n_recv (integer, allocatable, :, :)`: Number of items to receive from other processes.
+
+- **`mg_bc_t`**: Defines a boundary condition type and associated data.
+  - `bc_type (integer)`: Type of boundary condition (e.g., `mg_bc_dirichlet`, `mg_bc_neumann`). Default: `mg_bc_dirichlet`.
+  - `bc_value (real(dp))`: Value associated with the boundary condition (e.g., Dirichlet value, Neumann flux). Default: `0.0_dp`.
+  - `boundary_cond (procedure(mg_subr_bc), pointer, nopass)`: Procedure pointer to a user-defined subroutine for applying physical boundary conditions. Default: `null()`.
+  - `refinement_bnd (procedure(mg_subr_rb), pointer, nopass)`: Procedure pointer to a user-defined subroutine for handling refinement boundaries (interpolating from coarse to fine). Default: `null()`.
+
+- **`mg_timer_t`**: Structure for simple performance timers.
+  - `name (character(len=20))`: Name of the timer.
+  - `t (real(dp))`: Accumulated time. Default: `0.0_dp`.
+  - `t0 (real(dp))`: Start time of the current timing interval.
+
+- **`mg_t`**: The main derived type encapsulating the entire multigrid hierarchy and its associated settings and data.
+  - `tree_created (logical)`: True if the basic tree structure has been built. Default: `.false.`.
+  - `is_allocated (logical)`: True if memory for box data (`cc` arrays, buffers) has been allocated. Default: `.false.`.
+  - `n_extra_vars (integer)`: Number of additional user-defined cell-centered variables. Default: `0`.
+  - `comm (integer)`: MPI communicator. Default: `-1`.
+  - `n_cpu (integer)`: Total number of MPI processes. Default: `-1`.
+  - `my_rank (integer)`: Rank of the current MPI process. Default: `-1`.
+  - `box_size (integer)`: Number of cells per side for boxes at the reference level (level 1). Default: `-1`.
+  - `highest_lvl (integer)`: Highest (finest) refinement level present in the grid. Default: `-1`.
+  - `lowest_lvl (integer)`: Lowest (coarsest) refinement level present in the grid. Default: `-1`.
+  - `first_normal_lvl (integer)`: Coarsest level at which children fully populate $2^{NDIM}$ sub-regions of their parent. Below this, parents might have only one child (special coarsening). Default: `-1`.
+  - `n_boxes (integer)`: Total number of boxes in the grid across all processes. Default: `0`.
+  - `box_size_lvl(mg_lvl_lo:mg_lvl_hi) (integer)`: Box size (cells per side) for each level.
+  - `domain_size_lvl(NDIM, mg_lvl_lo:mg_lvl_hi) (integer)`: Effective domain size in cells for each level if uniformly refined.
+  - `dr(NDIM, mg_lvl_lo:mg_lvl_hi) (real(dp))`: Grid spacing for each level.
+  - `r_min(NDIM) (real(dp))`: Physical coordinates of the minimum corner of the overall domain.
+  - `lvls(mg_lvl_lo:mg_lvl_hi) (type(mg_lvl_t))`: Array of level structures.
+  - `boxes (type(mg_box_t), allocatable, :)`: Array containing all box structures in the grid.
+  - `buf (type(mg_buf_t), allocatable, :)`: Array of communication buffers, one for each MPI process.
+  - `comm_restrict (type(mg_comm_t))`: Communication pattern info for restriction.
+  - `comm_prolong (type(mg_comm_t))`: Communication pattern info for prolongation.
+  - `comm_ghostcell (type(mg_comm_t))`: Communication pattern info for ghost cell filling.
+  - `phi_bc_data_stored (logical)`: Flag indicating if boundary condition data for the solution variable has been stored. Default: `.false.`.
+  - `periodic(NDIM) (logical)`: Flags indicating periodicity in each dimension. Default: `.false.`.
+  - `bc(mg_num_neighbors, mg_max_num_vars) (type(mg_bc_t))`: Array to store pre-defined boundary conditions for each face and variable.
+  - `operator_type (integer)`: Type of PDE operator (e.g., `mg_laplacian`). Default: `mg_laplacian`.
+  - `geometry_type (integer)`: Type of coordinate system (e.g., `mg_cartesian`). Default: `mg_cartesian`.
+  - `subtract_mean (logical)`: Whether to subtract the mean from the solution (e.g., for pure Neumann Poisson). Default: `.false.`.
+  - `smoother_type (integer)`: Type of multigrid smoother (e.g., `mg_smoother_gs`). Default: `mg_smoother_gs`.
+  - `n_smoother_substeps (integer)`: Number of substeps for the smoother (e.g., 2 for Red-Black Gauss-Seidel). Default: `1`.
+  - `n_cycle_down (integer)`: Number of smoothing steps during the downward (restriction) leg of a V-cycle. Default: `2`.
+  - `n_cycle_up (integer)`: Number of smoothing steps during the upward (prolongation) leg of a V-cycle. Default: `2`.
+  - `max_coarse_cycles (integer)`: Maximum number of iterations on the coarsest grid. Default: `1000`.
+  - `coarsest_grid(NDIM) (integer)`: Minimum box size on the coarsest grid. Default: `2` cells per side.
+  - `residual_coarse_abs (real(dp))`: Absolute residual tolerance for stopping coarse grid solve. Default: `1e-8_dp`.
+  - `residual_coarse_rel (real(dp))`: Relative residual reduction factor for stopping coarse grid solve. Default: `1e-8_dp`.
+  - `box_op (procedure(mg_box_op), pointer, nopass)`: Procedure pointer for the main PDE operator. Default: `null()`.
+  - `box_smoother (procedure(mg_box_gsrb), pointer, nopass)`: Procedure pointer for the smoother. Default: `null()`.
+  - `box_prolong (procedure(mg_box_prolong), pointer, nopass)`: Procedure pointer for the prolongation operator. Default: `null()`.
+  - `n_timers (integer)`: Number of active timers. Default: `0`.
+  - `timers(mg_max_timers) (type(mg_timer_t))`: Array of timer structures.
+
+### Abstract Interfaces
+
+These define the signatures for procedure pointers used in `mg_t` and `mg_bc_t`.
+- **`mg_subr_bc`**: For user-defined physical boundary condition routines.
+  - **Arguments:** `box (mg_box_t, in)`, `nc (integer, in)`, `iv (integer, in)`, `nb (integer, in)`, `bc_type (integer, out)`, `bc (real(dp), out, array)`
+- **`mg_subr_rb`**: For user-defined refinement boundary routines (interpolation from coarse grid data `cgc`).
+  - **Arguments:** `box (mg_box_t, inout)`, `nc (integer, in)`, `iv (integer, in)`, `nb (integer, in)`, `cgc (real(dp), in, array)`
+- **`mg_box_op`**: For routines that apply the discretized PDE operator (e.g., $L\phi$).
+  - **Arguments:** `mg (mg_t, inout)`, `id (integer, in)`, `nc (integer, in)`, `i_out (integer, in)`
+- **`mg_box_gsrb`**: For smoother routines (e.g., Gauss-Seidel Red-Black).
+  - **Arguments:** `mg (mg_t, inout)`, `id (integer, in)`, `nc (integer, in)`, `redblack_cntr (integer, in)`
+- **`mg_box_prolong`**: For prolongation routines (interpolating data from a parent box to a child).
+  - **Arguments:** `mg (mg_t, inout)`, `p_id (integer, in)`, `dix(NDIM) (integer, in)`, `nc (integer, in)`, `iv (integer, in)`, `fine (real(dp), out, array)`
+
+### Important Variables/Constants (Parameters)
+
+- **Precision:**
+  - `dp (integer, parameter)`: Kind parameter for double precision reals (from `kind(0.0d0)`).
+  - `i8 (integer, parameter)`: Kind parameter for 64-bit integers (from `selected_int_kind(18)`).
+- **Operator Types:** `mg_laplacian`, `mg_vlaplacian` (variable coefficient), `mg_helmholtz`, `mg_vhelmholtz`, `mg_ahelmholtz` (anisotropic Helmholtz).
+- **Geometry Types:** `mg_cartesian`, `mg_cylindrical`, `mg_spherical`.
+- **Smoother Types:** `mg_smoother_gs` (Gauss-Seidel), `mg_smoother_gsrb` (Gauss-Seidel Red-Black), `mg_smoother_jacobi`.
+- **Dimensionality:**
+  - `mg_ndim (integer, parameter)`: Problem dimension, set by preprocessor `NDIM`.
+- **Variable Indices (for `mg_box_t%cc` array):**
+  - `mg_num_vars (integer, parameter)`: Number of predefined variables (4: phi, rhs, old_phi, residual).
+  - `mg_max_num_vars (integer, parameter)`: Maximum allowed variables (10).
+  - `mg_iphi (integer, parameter)`: Index for the solution variable $\phi$.
+  - `mg_irhs (integer, parameter)`: Index for the right-hand side $f$.
+  - `mg_iold (integer, parameter)`: Index for the previous solution (used in correction scheme).
+  - `mg_ires (integer, parameter)`: Index for the residual $f - L\phi$.
+  - `mg_iveps (integer, parameter)`: Index for isotropic variable coefficient $\epsilon$.
+  - `mg_iveps1`, `mg_iveps2`, `mg_iveps3 (integer, parameter)`: Indices for anisotropic coefficients $\epsilon_x, \epsilon_y, \epsilon_z$ (existence depends on `NDIM`).
+- **Grid Level Limits:** `mg_lvl_lo`, `mg_lvl_hi` (parameters defining min/max level indices).
+- **Boundary Condition Types:** `mg_bc_dirichlet`, `mg_bc_neumann`, `mg_bc_continuous`.
+- **Special Box/Neighbor IDs:**
+  - `mg_no_box (integer, parameter)`: Indicates no box (e.g., a child pointer for a leaf box).
+  - `mg_physical_boundary (integer, parameter)`: Indicates a neighbor link pointing to a physical domain boundary.
+- **Timers:** `mg_max_timers (integer, parameter)`: Maximum number of timers.
+- **Geometric/Topological Constants (NDIM-dependent, defined via C-preprocessor):**
+  - `mg_num_children (integer, parameter)`: $2^{NDIM}$.
+  - `mg_child_dix(NDIM, mg_num_children) (integer, parameter)`: Index offsets of children relative to parent's logical index space.
+  - `mg_child_rev(mg_num_children, NDIM) (integer, parameter)`: Mapping to find a child's index if looking from an adjacent parent.
+  - `mg_child_adj_nb(mg_num_children/2, 2*NDIM) (integer, parameter)`: Children adjacent to a specific neighbor face.
+  - `mg_child_low(NDIM, mg_num_children) (logical, parameter)`: Flags indicating if a child is on the "low" side in each dimension.
+  - `mg_num_neighbors (integer, parameter)`: $2 \times NDIM$.
+  - `mg_neighb_lowx`, `mg_neighb_highx`, etc. (integer, parameter): Named constants for neighbor directions.
+  - `mg_neighb_dix(NDIM, mg_num_neighbors) (integer, parameter)`: Index offsets to find neighbors.
+  - `mg_neighb_low(mg_num_neighbors) (logical, parameter)`: Flags indicating if a neighbor is in the "low" direction.
+  - `mg_neighb_high_pm(mg_num_neighbors) (integer, parameter)`: `[-1, 1]` representation for low/high neighbors.
+  - `mg_neighb_rev(mg_num_neighbors) (integer, parameter)`: Opposite direction for each neighbor.
+  - `mg_neighb_dim(mg_num_neighbors) (integer, parameter)`: Dimension corresponding to each neighbor direction.
+
+### Module Subroutines/Functions
+
+Besides type/constant definitions, the module also contains several public utility functions:
+- **`mg_has_children(box)`**: Elemental function, returns `.true.` if `box%children(1)` is not `mg_no_box`.
+- **`mg_ix_to_ichild(ix)`**: Calculates a child's index (1 to $2^{NDIM}$) within its parent's `children` array based on its logical spatial index `ix`.
+- **`mg_get_child_offset(mg, id)`**: Returns the spatial offset of a child box relative to its parent's origin, in units of child cell width.
+- **`mg_highest_uniform_lvl(mg)`**: Determines the highest level up to which the grid is uniformly refined.
+- **`mg_number_of_unknowns(mg)`**: Calculates the total number of unknowns (degrees of freedom) on all leaf boxes.
+- **`mg_get_face_coords(box, nb, nc, x)`**: Calculates physical coordinates of cell centers on a specific face `nb` of a `box`.
+- **Timer routines:** `mg_add_timer`, `mg_timer_start`, `mg_timer_end`, `mg_timers_show` for managing and displaying simple performance timers.
+
+## Usage Examples
+
+```fortran
+! Example: Declaring mg_t and accessing box data
+use m_data_structures
+implicit none
+
+type(mg_t) :: my_multigrid_solver
+type(mg_box_t) :: current_box
+integer :: box_id, level_num, num_cells_per_side
+real(dp) :: solution_value, rhs_value
+integer :: i, j, k ! Cell indices
+
+! ... (Assume my_multigrid_solver is initialized, tree built, and storage allocated)
+! ... (Assume box_id is a valid ID for a box owned by the current process)
+
+! Get a reference to a specific box (conceptual, direct access might be via mg%boxes(box_id))
+! current_box = my_multigrid_solver%boxes(box_id) ! This is how you'd actually get it
+
+! For demonstration, let's assume current_box is somehow populated:
+! (This is just for showing access, not functional code for getting a box)
+level_num = 1
+current_box%lvl = level_num
+current_box%id = box_id
+num_cells_per_side = my_multigrid_solver%box_size_lvl(level_num)
+
+! Allocate cell-centered data for the box (nc = num_cells_per_side)
+! The DTIMES macro handles dimensions, assuming 0:nc+1 for ghost cells
+! Let's say mg_num_vars + n_extra_vars = 5
+#if NDIM == 3
+  allocate(current_box%cc(0:num_cells_per_side+1, 0:num_cells_per_side+1, 0:num_cells_per_side+1, 5))
+#elif NDIM == 2
+  allocate(current_box%cc(0:num_cells_per_side+1, 0:num_cells_per_side+1, 5))
+#else
+  allocate(current_box%cc(0:num_cells_per_side+1, 5))
+#endif
+current_box%cc = 0.0_dp ! Initialize
+
+! Example: Accessing data within a 3D box at cell (i,j,k)
+i = num_cells_per_side / 2
+j = num_cells_per_side / 2
+k = num_cells_per_side / 2
+
+! Set and get solution (phi) and RHS values
+#if NDIM == 3
+  current_box%cc(i,j,k, mg_iphi) = 1.23_dp
+  current_box%cc(i,j,k, mg_irhs) = 4.56_dp
+  solution_value = current_box%cc(i,j,k, mg_iphi)
+  rhs_value      = current_box%cc(i,j,k, mg_irhs)
+  print *, "3D Example: Solution at box", box_id, "cell (",i,j,k,") is", solution_value
+#elif NDIM == 2
+  current_box%cc(i,j, mg_iphi) = 1.23_dp
+  current_box%cc(i,j, mg_irhs) = 4.56_dp
+  solution_value = current_box%cc(i,j, mg_iphi)
+  rhs_value      = current_box%cc(i,j, mg_irhs)
+  print *, "2D Example: Solution at box", box_id, "cell (",i,j,") is", solution_value
+#else
+  current_box%cc(i, mg_iphi) = 1.23_dp
+  current_box%cc(i, mg_irhs) = 4.56_dp
+  solution_value = current_box%cc(i, mg_iphi)
+  rhs_value      = current_box%cc(i, mg_irhs)
+  print *, "1D Example: Solution at box", box_id, "cell (",i,") is", solution_value
+#endif
+
+! Accessing other properties of the mg_t structure
+print *, "Multigrid solver configured for operator type:", my_multigrid_solver%operator_type
+print *, "Grid periodicity in X-dim:", my_multigrid_solver%periodic(1)
+
+if (allocated(current_box%cc)) deallocate(current_box%cc)
+
+```
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - Primarily uses intrinsic Fortran capabilities.
+  - Uses `mpi` module in timer functions (`mg_timer_start`, `mg_timer_end`, `mg_timers_show`) for `mpi_wtime()` and `mpi_reduce()`.
+- **External Libraries:**
+  - `cpp_macros.h`: This C-preprocessor include is used for `NDIM` (which defines the dimensionality compiled into the library) and `DTIMES` (which likely expands to the appropriate number of colons for array slicing based on `NDIM`).
+- **Interactions with Other Components:**
+  - This module is fundamental to the entire `m_octree_mg` library. Nearly every other Fortran module in the `src/` directory will `use m_data_structures` to access the definitions of `mg_t`, `mg_box_t`, `mg_lvl_t`, various constants (like `mg_iphi`, `mg_bc_dirichlet`), and procedure interfaces. It provides the common vocabulary and data framework for all other components that build, manipulate, solve on, or communicate about the multigrid structure.
+```

--- a/docs/src/doc_m_diffusion.f90.md
+++ b/docs/src/doc_m_diffusion.f90.md
@@ -1,0 +1,135 @@
+# `m_diffusion.f90`
+
+## Overview
+
+The `m_diffusion` module provides high-level solver routines for time-dependent diffusion problems, typically of the form $\frac{\partial \phi}{\partial t} = \nabla \cdot (D \nabla \phi) + S$, where $D$ is the diffusion coefficient (tensor) and $S$ is a source term (though source terms are implicitly handled by the RHS construction). This module transforms the time-discretized diffusion equation into a Helmholtz-type equation, which is then solved using the multigrid capabilities of the `m_octree_mg` library. It supports constant, variable isotropic, and variable anisotropic diffusion coefficients by leveraging specialized Helmholtz solver modules (`m_helmholtz`, `m_vhelmholtz`, `m_ahelmholtz`). Both first-order (e.g., backward Euler) and second-order (e.g., Crank-Nicolson) time discretizations are supported for the diffusion term.
+
+## Key Components
+
+### Modules
+
+- **`m_diffusion`:** Contains public subroutines for solving different types of diffusion equations.
+
+### Functions/Subroutines
+
+The module provides three main public solver routines, each tailored to a different type of diffusion coefficient:
+
+- **`diffusion_solve(mg, dt, diffusion_coeff, order, max_res)`:**
+  - **Description:** Solves a diffusion equation where the diffusion coefficient `diffusion_coeff` is constant throughout the domain. It internally sets `mg%operator_type = mg_helmholtz` and uses the `m_helmholtz` module to perform the solution.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure. The solution $\phi^t$ is expected in `mg%boxes(:)%cc(..., mg_iphi)` and is overwritten by $\phi^{t+dt}$.
+    - `dt (real(dp), intent(in))`: The time step size.
+    - `diffusion_coeff (real(dp), intent(in))`: The constant diffusion coefficient.
+    - `order (integer, intent(in))`: Time discretization order (1 or 2).
+    - `max_res (real(dp), intent(in))`: The desired maximum residual for the solver.
+
+- **`diffusion_solve_vcoeff(mg, dt, order, max_res)`:**
+  - **Description:** Solves a diffusion equation with a variable isotropic diffusion coefficient. The coefficient values are expected to be pre-loaded into the `mg_iveps` component of the `mg%boxes(:)%cc` arrays at all relevant grid levels. It internally sets `mg%operator_type = mg_vhelmholtz` and uses the `m_vhelmholtz` module.
+  - **Arguments:** (Same as `diffusion_solve`, but `diffusion_coeff` is implicit via `mg_iveps`)
+    - `mg (type(mg_t), intent(inout))`
+    - `dt (real(dp), intent(in))`
+    - `order (integer, intent(in))`
+    - `max_res (real(dp), intent(in))`
+
+- **`diffusion_solve_acoeff(mg, dt, order, max_res)`:**
+  - **Description:** Solves a diffusion equation with an anisotropic diffusion coefficient. The components of the diffusion tensor are expected to be pre-loaded into `mg_iveps1` (for $D_{xx}$), `mg_iveps2` (for $D_{yy}$), and `mg_iveps3` (for $D_{zz}$) components of `mg%boxes(:)%cc` at all relevant grid levels. It internally sets `mg%operator_type = mg_ahelmholtz` and uses the `m_ahelmholtz` module.
+  - **Arguments:** (Same as `diffusion_solve_vcoeff`)
+    - `mg (type(mg_t), intent(inout))`
+    - `dt (real(dp), intent(in))`
+    - `order (integer, intent(in))`
+    - `max_res (real(dp), intent(in))`
+
+**Common Solver Logic:**
+1.  Set the appropriate `mg%operator_type` (e.g., `mg_helmholtz`).
+2.  Call `mg_set_methods(mg)` (from `m_multigrid`) to associate the correct operator and smoother routines from the chosen Helmholtz module with the function pointers in `mg%box_op` and `mg%box_smoother`.
+3.  Determine the `lambda` parameter for the Helmholtz equation based on `dt`, `diffusion_coeff` (if applicable), and `order`.
+4.  Construct the right-hand side (RHS) of the Helmholtz equation using the private `set_rhs` subroutine. This involves terms from $\phi^t$. For `order=2`, it also includes a term $L_{op}(\phi^t)$, where $L_{op}$ is the spatial diffusion operator part, effectively moving known terms to the RHS.
+5.  Execute a Full Multigrid (FMG) cycle using `mg_fas_fmg`.
+6.  Iteratively call V-cycles (`mg_fas_vcycle`) until the residual `res` is less than or equal to `max_res`, or a maximum iteration count (`max_its = 10`) is reached.
+7.  If convergence is not achieved, an error is raised.
+
+### Private Helper Subroutines
+
+- **`set_rhs(mg, f1, f2)`:**
+  - **Description:** This subroutine computes the right-hand side for the Helmholtz-like equation that results from the time discretization of the diffusion equation.
+    For a scheme like $(\alpha I - \beta D_0 \Delta t \nabla^2) \phi^{n+1} = \gamma \phi^n + \delta D_0 \Delta t \nabla^2 \phi^n + S'$, this routine effectively calculates $\text{RHS} = \text{f1} \cdot \phi^n + \text{f2} \cdot (\text{previous content of } mg\_irhs)$.
+    The `mg_irhs` field in `mg%boxes(:)%cc` is overwritten with this new RHS.
+    - If `order = 1`: $\text{RHS} = (1/(\text{dt} \cdot D)) \phi^n$ (for constant D, simplified). `f1 = 1/(\text{dt} \cdot D)`, `f2 = 0`.
+    - If `order = 2`: $\text{RHS} = (2/(\text{dt} \cdot D)) \phi^n + \nabla^2 \phi^n$. `f1 = 2/(\text{dt} \cdot D)`, `f2 = -1` (since $\nabla^2 \phi^n$ was stored in `mg_irhs` by `mg_apply_op` with a negative sign from the Helmholtz convention $L\phi = (\nabla^2 - \lambda)\phi$).
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `f1 (real(dp), intent(in))`: Factor multiplying the current solution $\phi^t$ (stored in `mg_iphi`).
+    - `f2 (real(dp), intent(in))`: Factor multiplying the previous content of `mg_irhs` (which for `order=2` holds the result of applying the spatial operator to $\phi^t$).
+
+## Important Variables/Constants
+
+- **`max_its (integer, parameter, local to each public solver)`:** Maximum number of V-cycles allowed after the initial FMG cycle. Hardcoded to `10`.
+- **Variable Interpretation:**
+  - `mg%boxes(:)%cc(..., mg_iphi)`: Input is $\phi^t$, output is $\phi^{t+dt}$.
+  - `mg%boxes(:)%cc(..., mg_irhs)`: Used to construct the RHS of the Helmholtz solver.
+  - `mg%boxes(:)%cc(..., mg_iveps*)`: Stores diffusion coefficients for variable/anisotropic cases.
+- **`dt (real(dp))`**: Timestep. Critical for stability and accuracy, and for setting Helmholtz $\lambda$.
+- **`order (integer)`**: Time discretization order (1 or 2).
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Essential for `type(mg_t)` and its components (e.g., `mg_iphi`, `mg_irhs`, `mg_iveps`, `operator_type`), and various constants.
+  - **`m_multigrid`:** Crucial for `mg_set_methods` (to link the correct Helmholtz operator/smoother), `mg_apply_op` (used in `order=2` schemes to compute $L\phi^t$), `mg_fas_fmg`, and `mg_fas_vcycle` (the core multigrid solution algorithms).
+  - **`m_helmholtz`:** Provides `helmholtz_set_lambda`; its operator/smoother are used by `diffusion_solve`.
+  - **`m_vhelmholtz`:** Provides `vhelmholtz_set_lambda`; its operator/smoother are used by `diffusion_solve_vcoeff`.
+  - **`m_ahelmholtz`:** Provides `ahelmholtz_set_lambda`; its operator/smoother are used by `diffusion_solve_acoeff`.
+- **External Libraries:**
+  - **`cpp_macros.h`:** Used for the `DTIMES` macro in `set_rhs` for dimension-agnostic array indexing.
+- **Interactions with Other Components:**
+  - This module serves as a high-level application driver that orchestrates the use of underlying multigrid solvers for a specific physical problem (diffusion).
+  - **Calling Code:** The user must:
+    1.  Initialize the `mg_t` structure (grid, MPI setup, boundary conditions via `mg%bc`).
+    2.  Store the initial condition $\phi^t$ in `mg%boxes(:)%cc(..., mg_iphi)`.
+    3.  For `diffusion_solve_vcoeff` or `diffusion_solve_acoeff`, ensure the diffusion coefficients are correctly populated in the `mg_iveps*` fields of `mg%boxes(:)%cc` *on all grid levels* that will be used by the solver. This often requires defining how coefficients are restricted to coarser grids.
+  - **Output:** The new solution $\phi^{t+dt}$ is stored in `mg%boxes(:)%cc(..., mg_iphi)`.
+
+## Usage Examples
+
+```fortran
+! Conceptual example: Solving a time step of diffusion
+! with a constant diffusion coefficient.
+
+use m_data_structures
+use m_diffusion
+! Assume 'mg_state' is a type(mg_t) variable that has been fully initialized:
+! - MPI setup done (e.g., via mg_comm_init)
+! - Tree built (e.g., via mg_build_rectangle)
+! - Storage allocated (e.g., via mg_allocate_storage)
+! - Boundary conditions for mg_iphi are set in mg_state%bc
+! - Initial solution phi_t is loaded into mg_state%boxes(:)%cc(..., mg_iphi)
+
+implicit none
+
+type(mg_t) :: mg_state
+real(dp)   :: time_step_val
+real(dp)   :: const_diffusion_coeff
+integer    :: discretization_order_val
+real(dp)   :: convergence_tolerance
+
+! Parameters for the diffusion solve
+time_step_val            = 0.001_dp
+const_diffusion_coeff    = 0.1_dp
+discretization_order_val = 2  ! Use a second-order time scheme (e.g., Crank-Nicolson like)
+convergence_tolerance    = 1.0e-8_dp
+
+! Call the diffusion solver for one time step
+call diffusion_solve(mg_state, time_step_val, const_diffusion_coeff, &
+                     discretization_order_val, convergence_tolerance)
+
+! The updated solution phi_(t+dt) is now in mg_state%boxes(:)%cc(..., mg_iphi)
+print *, "Diffusion step completed. Solution updated."
+
+! To solve with a variable coefficient (assuming D is in mg_iveps):
+! call diffusion_solve_vcoeff(mg_state, time_step_val, &
+!                             discretization_order_val, convergence_tolerance)
+
+! To solve with an anisotropic coefficient (assuming Dxx, Dyy, Dzz are in mg_iveps1/2/3):
+! call diffusion_solve_acoeff(mg_state, time_step_val, &
+!                             discretization_order_val, convergence_tolerance)
+```

--- a/docs/src/doc_m_free_space.f90.md
+++ b/docs/src/doc_m_free_space.f90.md
@@ -1,0 +1,157 @@
+# `m_free_space.f90`
+
+## Overview
+
+The `m_free_space` module provides a specialized solver for Poisson's equation ($\nabla^2 \phi = \rho$) in a three-dimensional Cartesian domain under free-space (open or unbounded) boundary conditions. This is particularly useful when the influence of charges or sources extends to infinity, and a fixed potential or zero-flux condition at a finite boundary is inappropriate.
+
+The core idea is to use a Fast Fourier Transform (FFT) based Poisson solver (from an external `poisson_solver` module) on a chosen, potentially coarser, grid level (`fft_lvl`) of the multigrid hierarchy. This FFT solve computes the potential due to the overall source distribution as if it were in infinite space. The potential values from the faces of this FFT solution domain are then extracted and used as Dirichlet boundary conditions for the main multigrid solver, which handles the solution on finer grid levels or refines the solution on the `fft_lvl` itself.
+
+**Note:** This module's functionality is only available when the library is compiled for `NDIM == 3`.
+
+## Key Components
+
+### Modules
+
+- **`m_free_space`:** Encapsulates the logic for the free-space Poisson solver.
+
+### Conditional Compilation
+The entire module is conditionally compiled using `#if NDIM == 3 ... #endif`. If `NDIM` is not 3, this module provides no public interface or functionality.
+
+### Derived Type Definition
+
+- **`mg_free_bc_t` (private):** This type stores the state and data required for the free-space boundary condition calculation.
+  - `initialized (logical)`: A flag, `.true.` if the FFT-derived boundary data has been computed and is ready.
+  - `fft_lvl (integer)`: The multigrid level on which the FFT-based global solve was performed.
+  - `rhs (real(dp), allocatable, :,:,:)`: An array holding the right-hand side (source term $\rho$) for the FFT solver, potentially padded for FFT requirements and aggregated from all MPI processes.
+  - `karray (real(dp), pointer, :)`: A pointer to the Green's function kernel in Fourier space, obtained from the `poisson_solver` module.
+  - `inv_dr(2, mg_num_neighbors) (real(dp))`: Inverse grid spacings for the two perpendicular directions on each of the six boundary faces of the `fft_lvl` domain. Used for interpolation.
+  - `r_min(2, mg_num_neighbors) (real(dp))`: Minimum coordinates for the two perpendicular directions on each boundary face. Used for interpolation.
+  - `bc_x0, bc_x1, bc_y0, bc_y1, bc_z0, bc_z1 (real(dp), allocatable, :,:)`: Arrays storing the computed potential values on the six faces (low/high x, y, z) of the `fft_lvl` domain. These serve as the Dirichlet data for the multigrid solver.
+
+### Module Variable
+
+- **`free_bc (type(mg_free_bc_t))` (private):** A module-level variable of type `mg_free_bc_t` that holds the persistent state of the free-space boundary calculation across calls.
+
+### Public Subroutines
+
+- **`mg_poisson_free_3d(mg, new_rhs, max_fft_frac, fmgcycle, max_res)`:**
+  - **Description:** This is the primary public routine for solving the 3D free-space Poisson problem.
+    1.  It first checks that the geometry is Cartesian and the operator is Laplacian.
+    2.  It determines an optimal `fft_lvl` for the FFT solve. This level is chosen such that the number of unknowns on it is less than or equal to `max_fft_frac` times the total number of unknowns on the leaf nodes of the entire grid.
+    3.  If `new_rhs` is `.true.` or if the determined `fft_lvl` has changed since the last call (or if it's the first call):
+        *   The source term `mg_irhs` is restricted from finer levels down to `fft_lvl`.
+        *   The Green's function kernel `free_bc%karray` is obtained by calling `createKernel` from the `poisson_solver` module.
+        *   The RHS for the FFT solver is prepared in `free_bc%rhs` by gathering (MPI_Allreduce) and scaling (`rhs_fac = -1/(4\pi)`) the source term from `mg%boxes(:)%cc(..., mg_irhs)` on `fft_lvl`.
+        *   The external `PSolver` routine (from `poisson_solver`) is called to compute the potential on the `fft_lvl` grid using FFT methods.
+        *   The potential values on the six faces of this `fft_lvl` domain are extracted from the `PSolver` output and stored in `free_bc%bc_x0`, etc.
+        *   These boundary values are registered with the multigrid framework via `mg_phi_bc_store`.
+        *   The solution from `PSolver` is used as an initial guess for `mg_iphi` on `fft_lvl`, and then restricted/prolonged to populate other levels as an initial guess.
+    4.  The `mg%bc(n, mg_iphi)%boundary_cond` procedure pointer is set to `ghost_cells_free_bc` for all faces, ensuring that subsequent ghost cell filling operations use the FFT-derived boundary data.
+    5.  If `fft_lvl` is coarser than the finest grid level (`mg%highest_lvl`), a standard multigrid cycle (`mg_fas_fmg` if `fmgcycle` is `.true.`, else `mg_fas_vcycle`) is performed to refine the solution.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `new_rhs (logical, intent(in))`: Set to `.true.` if the right-hand side (source term in `mg_irhs`) has changed or if this is the first call. If `.false.`, previously computed boundary data might be reused if `fft_lvl` is unchanged, and only multigrid refinement cycles are performed.
+    - `max_fft_frac (real(dp), intent(in))`: A fraction (0.0-1.0) controlling the maximum relative size of the FFT grid compared to the total grid.
+    - `fmgcycle (logical, intent(in))`: If `.true.`, an FMG cycle is performed by the multigrid solver. If `.false.`, a V-cycle is performed.
+    - `max_res (real(dp), intent(out), optional)`: If present, returns the maximum residual after the multigrid solve.
+
+### Private Helper Subroutines
+
+- **`ghost_cells_free_bc(box, nc, iv, nb, bc_type, bc)`:**
+  - **Description:** This subroutine is assigned to the `boundary_cond` procedure pointer in `mg%bc`. When ghost cells are filled for a `box` at a physical boundary, this routine is called. It sets the `bc_type` to `mg_bc_dirichlet` and calculates the potential values for the ghost cells (`bc`) by calling `interp_bc` to interpolate from the appropriate pre-computed boundary plane (`free_bc%bc_x0`, etc.).
+  - **Arguments:** Standard signature for `mg_subr_bc`.
+
+- **`interp_bc(current_free_bc_data, nb, x1, x2)` elemental function, result(val):**
+  - **Description:** Performs bilinear interpolation to find the potential `val` at a given point (`x1`, `x2` representing coordinates on a plane) on a specific boundary face `nb`. It uses the pre-calculated potential values stored in the `bc_x0`...`bc_z1` arrays within the `current_free_bc_data` (an instance of `mg_free_bc_t`).
+  - **Arguments:**
+    - `current_free_bc_data (type(mg_free_bc_t), intent(in))`: The stored free boundary condition data.
+    - `nb (integer, intent(in))`: The neighbor index indicating which boundary face.
+    - `x1, x2 (real(dp), intent(in))`: Coordinates on the boundary plane.
+    - `val (real(dp))`: The interpolated potential value.
+
+## Important Variables/Constants
+
+- **`rhs_fac (real(dp), parameter)`:** A scaling factor of `-1.0 / (4 * acos(-1.0_dp))` (i.e., $-1/(4\pi)$) applied to the source term `mg_irhs` before passing it to the `PSolver`. This is because the Green's function for the Laplacian $\nabla^2 G = \delta(\mathbf{r})$ is typically $-1/(4\pi |\mathbf{r}|)$.
+- **`free_bc%fft_lvl`**: Determines the grid level for the FFT-based global solve.
+- **`mg_iphi`**: Stores the solution (potential $\phi$).
+- **`mg_irhs`**: Stores the source term (charge density $\rho$).
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Essential for `type(mg_t)`, `type(mg_box_t)`, parameter constants like `mg_iphi`, `mg_irhs`, `mg_num_neighbors`, `mg_neighb_dim`, `mg_bc_dirichlet`, etc.
+- **External Libraries/Modules:**
+  - **`mpi`:** Used in `mg_poisson_free_3d` for `MPI_ALLREDUCE` to sum the RHS across processes for the FFT solver.
+  - **`poisson_solver` (external module):** This is a critical dependency. `m_free_space` calls `createKernel` to get the Green's function in Fourier space and `PSolver` to perform the actual FFT-based solution of the Poisson equation on the `fft_lvl` grid.
+  - **`m_multigrid`:** Uses `mg_fas_fmg` and `mg_fas_vcycle` for the main multigrid solution cycles, and `mg_phi_bc_store` to register the boundary conditions.
+  - **`m_restrict`:** Uses `mg_restrict_lvl` to transfer the source term and initial guess solution down to coarser levels.
+  - **`m_prolong`:** Uses `mg_prolong` to transfer the initial guess solution from `fft_lvl` to finer levels.
+  - **`m_ghost_cells`:** While the custom `ghost_cells_free_bc` provides the values, the framework calling `mg_fill_ghost_cells_lvl` (from `m_ghost_cells`) would trigger its execution.
+- **Interactions with Other Components:**
+  - This module provides a specialized solution strategy for 3D Poisson equations requiring open (free-space) boundary conditions.
+  - It works in conjunction with the main multigrid solvers: the FFT provides a global solution component and sets boundary conditions, while the multigrid method refines this solution locally.
+  - It effectively replaces standard fixed-value or zero-flux boundary conditions at the domain edge with dynamically computed Dirichlet conditions derived from the global free-space solve.
+  - The accuracy of the free-space approximation depends on the chosen `fft_lvl` and the extent to which the sources are contained within this `fft_lvl` domain.
+
+## Usage Examples
+
+```fortran
+! Conceptual example for using the free-space Poisson solver.
+! This assumes the code is compiled for NDIM = 3.
+
+#if NDIM == 3
+use m_data_structures
+use m_free_space
+! Ensure other necessary modules like m_multigrid, m_default_settings etc. are used for setup.
+
+implicit none
+
+type(mg_t) :: mg_grid_config
+logical    :: is_new_problem_rhs
+real(dp)   :: fft_grid_size_fraction
+logical    :: perform_fmg_cycle
+real(dp)   :: final_residual
+
+! --- Setup mg_grid_config ---
+! (This part is complex and involves initializing the mg_t object,
+!  e.g., using routines from m_default_settings, m_build_tree, m_allocate_storage.
+!  It's crucial that mg_grid_config%operator_type is set to mg_laplacian,
+!  and geometry is mg_cartesian.)
+!
+! Example:
+! call mg_init_default(mg_grid_config) ! (Hypothetical setup)
+! mg_grid_config%operator_type = mg_laplacian
+! mg_grid_config%geometry_type = mg_cartesian
+! call mg_build_rectangle(...)
+! call mg_load_balance_serial(mg_grid_config) ! (Hypothetical setup)
+! call mg_allocate_storage(mg_grid_config)
+!
+! Load the source term (e.g., charge density) into mg_grid_config%boxes(:)%cc(..., mg_irhs)
+! --- End Setup ---
+
+
+! Parameters for the free-space solver call
+is_new_problem_rhs     = .true.  ! True if RHS changed or first solve
+fft_grid_size_fraction = 0.5_dp  ! FFT grid has at most 50% of total unknowns
+perform_fmg_cycle      = .true.  ! Use FMG for the multigrid part
+
+call mg_poisson_free_3d(mg_grid_config, is_new_problem_rhs, &
+                         fft_grid_size_fraction, perform_fmg_cycle, &
+                         final_residual)
+
+print *, "Free-space Poisson solution completed."
+print *, "Final residual from multigrid part: ", final_residual
+! The solution (potential phi) is now in mg_grid_config%boxes(:)%cc(..., mg_iphi)
+
+! If you want to perform more V-cycles on an existing problem (RHS unchanged):
+! is_new_problem_rhs = .false.
+! perform_fmg_cycle  = .false. ! Perform a V-cycle
+! call mg_poisson_free_3d(mg_grid_config, is_new_problem_rhs, &
+!                         fft_grid_size_fraction, perform_fmg_cycle, &
+!                         final_residual)
+! print *, "Additional V-cycle completed. New residual: ", final_residual
+
+#else
+print *, "This example for m_free_space is only applicable for NDIM = 3."
+#endif
+```

--- a/docs/src/doc_m_ghost_cells.f90.md
+++ b/docs/src/doc_m_ghost_cells.f90.md
@@ -1,0 +1,127 @@
+# `m_ghost_cells.f90`
+
+## Overview
+
+The `m_ghost_cells` module plays a crucial role in the `m_octree_mg` library by managing the exchange and application of data in ghost cells (also known as halo or guard cells). Ghost cells are layers of virtual cells surrounding each computational box. They are filled with data from adjacent boxes—which may reside on the same MPI process or different MPI processes—or by applying physical or other boundary conditions (like those at refinement edges).
+
+Populating these ghost cells correctly is essential before applying any finite difference stencils (e.g., for Laplacian, Helmholtz, or other operators) near the boundaries of a box, ensuring that the stencil has access to valid data from logical neighbors. This module orchestrates the data transfer, applies various types of boundary conditions, and handles data interpolation at refinement boundaries (where grid levels of different resolutions meet).
+
+## Key Components
+
+### Modules
+
+- **`m_ghost_cells`:** Contains subroutines for calculating buffer sizes, packing data for communication, triggering MPI communication (via `m_communication`), and unpacking received data or applying boundary conditions to fill ghost cell regions.
+
+### Functions/Subroutines
+
+- **`mg_ghost_cell_buffer_size(mg, n_send, n_recv, dsize)`:**
+  - **Description:** Calculates the maximum required MPI communication buffer sizes for ghost cell data exchange across all relevant grid levels. It performs a "dry run" of the ghost cell buffering logic for each level to count the number of data elements to be sent and received by each process. The output `n_send` and `n_recv` arrays are typically used by `m_allocate_storage` to allocate sufficiently large buffers in `mg%buf`.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure. Communication needs are stored in `mg%comm_ghostcell`.
+    - `n_send (integer, intent(out), array)`: Maximum number of items to be sent by the current process to any other process.
+    - `n_recv (integer, intent(out), array)`: Maximum number of items to be received by the current process from any other process.
+    - `dsize (integer, intent(out))`: Size of a single data element being transferred (typically `nc**(NDIM-1)` for a face).
+
+- **`mg_fill_ghost_cells(mg, iv)`:**
+  - **Description:** A convenience routine that fills ghost cells for a specified variable `iv` across *all* active grid levels in the multigrid hierarchy, from `mg%lowest_lvl` to `mg%highest_lvl`. It does this by iteratively calling `mg_fill_ghost_cells_lvl`.
+  - **Arguments:**
+    - `mg (type(mg_t))`: The multigrid data structure.
+    - `iv (integer, intent(in))`: Index of the variable (e.g., `mg_iphi`, `mg_irhs`) for which ghost cells are to be filled.
+
+- **`mg_fill_ghost_cells_lvl(mg, lvl, iv)`:**
+  - **Description:** This is the core routine for populating ghost cells for a given variable `iv` at a specific grid `lvl`. The process involves:
+    1.  Iterating through all locally owned boxes (`my_ids`) on the level to prepare data that needs to be sent to neighboring boxes on other MPI processes (`buffer_ghost_cells`).
+    2.  Iterating through local boxes at refinement boundaries (`my_ref_bnds` on `lvl-1`) to prepare data for finer neighbors on `lvl` that are on other MPI processes (`buffer_refinement_boundaries`).
+    3.  Invoking `sort_and_transfer_buffers` (from `m_communication`) to perform the actual MPI send/receive operations.
+    4.  Iterating again through local boxes on the level to fill their ghost cells (`set_ghost_cells`). This step uses the data received from MPI, or copies data directly from local neighbors, or applies physical/refinement boundary conditions.
+  - **Arguments:**
+    - `mg (type(mg_t))`: The multigrid data structure.
+    - `lvl (integer, intent(in))`: The grid level on which to fill ghost cells.
+    - `iv (integer, intent(in))`: Index of the variable to be processed.
+
+- **`mg_phi_bc_store(mg)`:**
+  - **Description:** An optimization routine that pre-calculates and stores the ghost cell values resulting from physical boundary conditions for the primary solution variable (`mg_iphi`). These values are stored into the ghost cell region normally associated with the `mg_irhs` variable within each box's `cc` array. If `mg%phi_bc_data_stored` is `.true.`, `set_ghost_cells` will use this pre-computed data when `iv == mg_iphi`, avoiding redundant boundary condition calculations.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+
+### Private Helper Subroutines
+
+The module contains numerous private helper routines. Some of the key ones include:
+- `mg_phi_bc_store_lvl`: Worker routine for `mg_phi_bc_store` for a single level.
+- `buffer_ghost_cells`: Identifies and packs data from a local box that needs to be sent to its off-process neighbors.
+- `buffer_refinement_boundaries`: Packs data from a coarse box for its off-process fine neighbors at a refinement interface.
+- `set_ghost_cells`: Orchestrates the filling of ghost cells for a single box by determining the source of data for each neighbor face (MPI buffer, local copy, physical BC, refinement BC).
+- `fill_refinement_bnd`: Specifically handles filling ghost cells for faces at a refinement boundary, using either a user-defined procedure (`mg%bc(nb,iv)%refinement_bnd`) or the default `sides_rb` interpolation.
+- `copy_from_nb`: Directly copies data from a neighboring box on the same MPI process.
+- `buffer_for_nb` / `buffer_for_fine_nb`: Lower-level routines to place data into send buffers.
+- `fill_buffered_nb`: Retrieves data from a receive buffer and places it into a box's ghost cells.
+- `box_gc_for_neighbor` / `box_gc_for_fine_neighbor`: Extract data from the interior of a box that corresponds to a neighbor's ghost cell layer.
+- `box_get_gc` / `box_set_gc`: Low-level accessors to get or set data in the 1-cell wide ghost layer of a `mg_box_t%cc` array (e.g., at index 0 or `nc+1`).
+- `bc_to_gc`: Applies standard boundary conditions (Dirichlet, Neumann, continuous) by calculating ghost cell values based on interior points and the specified BC type and value.
+- `sides_rb`: The default routine for interpolating data at refinement boundaries, designed to preserve diffusive fluxes.
+
+## Important Variables/Constants
+
+- **Ghost Cell Width:** The implementation implicitly assumes a ghost cell layer that is one cell wide. This is evident in routines like `box_set_gc` and `bc_to_gc` which access indices `0` and `nc+1` (where `1..nc` are interior cells).
+- **Boundary Condition Types:** Constants like `mg_bc_dirichlet`, `mg_bc_neumann`, `mg_bc_continuous` (defined in `m_data_structures`) are interpreted by `bc_to_gc` to apply the correct formula.
+- **`mg%phi_bc_data_stored (logical)`:** A flag in `mg_t` indicating if `mg_phi_bc_store` has been called.
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** This is a fundamental dependency. The module extensively uses `type(mg_t)`, `type(mg_box_t)`, `type(mg_lvl_t)`, various named constants for neighbor indexing (e.g., `mg_num_neighbors`, `mg_neighb_rev`), variable indices (`mg_iphi`, `mg_irhs`), boundary condition types, and utility functions like `mg_get_child_offset`.
+  - **`m_communication`:** Relies on `sort_and_transfer_buffers` from this module to perform the actual MPI communication of packed ghost cell data.
+- **External Libraries:**
+  - **`cpp_macros.h`:** Used for the `DTIMES` macro, enabling dimension-agnostic array operations in routines like `set_rhs` (though `set_rhs` is not in this module, the same macro is used here).
+- **Interactions with Other Components:**
+  - **Operator and Solver Modules (e.g., `m_ahelmholtz`, `m_laplacian`, `m_multigrid`):** Any module that applies numerical stencils to the grid data typically requires `mg_fill_ghost_cells_lvl` to be called beforehand to ensure that data in the ghost cell regions is valid and up-to-date. This is essential for computing correct values at cells near box boundaries.
+  - **Multigrid Operations (`m_multigrid`):** Ghost cell updates are integral to the multigrid cycle:
+    - Before smoother applications on each level.
+    - Before calculating residuals on each level.
+    - After prolongation to ensure the newly interpolated values on the fine grid can be used to correctly fill ghost cells at boundaries, especially refinement boundaries.
+  - **Boundary Condition Customization:** Users can provide custom routines for physical boundary conditions and refinement boundary interpolation via procedure pointers in `mg%bc(nb, iv)%boundary_cond` and `mg%bc(nb, iv)%refinement_bnd` respectively. These are called by `set_ghost_cells` and `fill_refinement_bnd`. Modules like `m_free_space` utilize this to implement specialized boundary behaviors.
+  - **Initialization and Allocation (`m_allocate_storage`):** The `mg_ghost_cell_buffer_size` routine is typically called during the setup phase (e.g., from `m_allocate_storage`) to determine the necessary sizes for communication buffers.
+
+## Usage Examples
+
+```fortran
+! Conceptual example of filling ghost cells for a specific variable at a given level.
+
+use m_data_structures
+use m_ghost_cells
+! Assume 'mg_instance' is a fully initialized 'type(mg_t)' variable.
+! Assume 'current_level_idx' is the integer index of the level being processed.
+! Assume 'variable_to_update' is the index (e.g., mg_iphi) of the variable
+! in mg_instance%boxes(:)%cc whose ghost cells need updating.
+
+implicit none
+type(mg_t) :: mg_instance
+integer    :: current_level_idx
+integer    :: variable_to_update
+
+! ... (mg_instance is set up, tree created, storage allocated, data initialized) ...
+
+current_level_idx = mg_instance%highest_lvl ! Example: highest level
+variable_to_update = mg_iphi             ! Example: the solution variable
+
+! Fill ghost cells for 'variable_to_update' at 'current_level_idx'
+call mg_fill_ghost_cells_lvl(mg_instance, current_level_idx, variable_to_update)
+
+! At this point, numerical operators (smoothers, residual calculations) can be applied
+! to the boxes on 'current_level_idx', as their ghost cells are now consistent
+! with neighboring data and boundary conditions.
+
+! --- Example of using pre-stored boundary conditions for mg_iphi ---
+! This is an optimization if boundary conditions for mg_iphi are static.
+
+! During initialization phase, after defining mg_instance%bc:
+if (.not. mg_instance%phi_bc_data_stored) then
+  call mg_phi_bc_store(mg_instance)
+end if
+
+! Later, when needing to fill ghost cells for mg_iphi:
+call mg_fill_ghost_cells_lvl(mg_instance, current_level_idx, mg_iphi)
+! The call to set_ghost_cells inside mg_fill_ghost_cells_lvl will detect that
+! mg_phi_bc_data_stored is true and iv is mg_iphi, and will use the pre-calculated
+! values from the mg_irhs ghost region for physical boundaries.
+```

--- a/docs/src/doc_m_helmholtz.f90.md
+++ b/docs/src/doc_m_helmholtz.f90.md
@@ -1,0 +1,120 @@
+# `m_helmholtz.f90`
+
+## Overview
+
+The `m_helmholtz` module is responsible for implementing the constant-coefficient Helmholtz operator and its associated smoother within the `m_octree_mg` multigrid library. The Helmholtz equation typically takes the form $\nabla^2\phi - \lambda\phi = f$ (or, with a sign convention difference, $\Delta\phi + \lambda\phi = f$), where $\nabla^2$ (or $\Delta$) is the Laplacian operator, $\phi$ is the unknown field, $f$ is the source term, and $\lambda$ is a scalar constant. This module provides the discretized form of this operator and a Gauss-Seidel based smoother tailored for it, which can then be used by the main multigrid solver routines. If $\lambda = 0$, this module effectively solves the Poisson equation.
+
+## Key Components
+
+### Modules
+
+- **`m_helmholtz`:** Encapsulates the Helmholtz operator, smoother, and configuration routines.
+
+### Public Module Variable
+
+- **`helmholtz_lambda (real(dp), public, protected)`:**
+  - **Description:** Stores the global constant value for $\lambda$ used in the Helmholtz equation $\nabla^2\phi - \lambda\phi = f$. This value must be non-negative ($\ge 0$). It is initialized to `0.0_dp`.
+  - **Accessed by:** `helmholtz_set_lambda` (to set) and the private `box_gs_helmh` and `box_helmh` routines (to use).
+
+### Functions/Subroutines
+
+- **`helmholtz_set_methods(mg)`:**
+  - **Description:** Configures the provided multigrid structure (`mg` of type `mg_t`) to use the Helmholtz operator and smoother defined in this module. It achieves this by assigning the internal `box_helmh` subroutine to the `mg%box_op` procedure pointer and the `box_gs_helmh` subroutine to the `mg%box_smoother` procedure pointer. This routine currently supports `mg_cartesian` geometry and smoother types `mg_smoother_gs` (Gauss-Seidel) or `mg_smoother_gsrb` (Gauss-Seidel Red-Black).
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure to be configured.
+
+- **`helmholtz_set_lambda(lambda)`:**
+  - **Description:** Sets the value of the module-level variable `helmholtz_lambda`. It checks if the input `lambda` is non-negative; if `lambda < 0`, it stops with an error.
+  - **Arguments:**
+    - `lambda (real(dp), intent(in))`: The value to be used for $\lambda$ in the Helmholtz equation.
+
+### Private Module Procedures (Core Operations)
+
+- **`box_gs_helmh(mg, id, nc, redblack_cntr)`:**
+  - **Description:** This subroutine performs a Gauss-Seidel relaxation sweep (either standard or Red-Black, based on `mg%smoother_type`) for the Helmholtz equation on the data within a single computational box specified by `id`. It updates the solution variable (`mg_iphi`) using values from neighboring cells and the source term (`mg_irhs`). This is the core smoother routine used in multigrid cycles.
+  - **Arguments:** (Standard signature for `mg_box_gsrb` procedure pointer)
+    - `mg (type(mg_t), intent(inout))`: The multigrid structure.
+    - `id (integer, intent(in))`: ID of the box to process.
+    - `nc (integer, intent(in))`: Size of the box (number of cells in each direction).
+    - `redblack_cntr (integer, intent(in))`: Iteration counter, used for Red-Black ordering to determine which set of cells (red or black) to update.
+
+- **`box_helmh(mg, id, nc, i_out)`:**
+  - **Description:** This subroutine applies the discretized constant-coefficient Helmholtz operator ($\nabla^2\phi - \lambda\phi$) to the solution variable `phi` (stored at index `mg_iphi` in the box's `cc` array). The result of the operation is stored in the `i_out` component of the box's `cc` array. This is the core operator routine used, for example, in residual calculations.
+  - **Arguments:** (Standard signature for `mg_box_op` procedure pointer)
+    - `mg (type(mg_t), intent(inout))`: The multigrid structure.
+    - `id (integer, intent(in))`: ID of the box to process.
+    - `nc (integer, intent(in))`: Size of the box.
+    - `i_out (integer, intent(in))`: Index in the `cc` array where the operator result $L(\phi)$ will be stored.
+
+## Important Variables/Constants
+
+- **`helmholtz_lambda (real(dp))`**: The primary parameter of this module. If `helmholtz_lambda = 0.0_dp`, the operator becomes the Poisson operator.
+- **Discretization:** The Laplacian part ($\nabla^2\phi$) is discretized using a standard 7-point stencil in 3D (5-point in 2D, 3-point in 1D) based on second-order central differences.
+- **Smoother Factor:** In `box_gs_helmh`, `fac = 1.0_dp / (2 * sum(idr2) + helmholtz_lambda)` represents the inverse of the diagonal element of the discretized Helmholtz operator matrix, used in the Gauss-Seidel update formula. `idr2` contains $1/dr^2$ for each dimension.
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Essential for `type(mg_t)`, `type(mg_box_t)`, the kind parameter `dp`, `NDIM`, variable indices (`mg_iphi`, `mg_irhs`), geometry types (`mg_cartesian`), and smoother types (`mg_smoother_gs`, `mg_smoother_gsrb`).
+- **External Libraries:**
+  - **`cpp_macros.h`:** Used for conditional compilation (`#if NDIM == ...`) to provide dimension-specific implementations of the stencil operations in `box_gs_helmh` and `box_helmh`.
+- **Interactions with Other Components:**
+  - **`m_multigrid`:** This is the primary consumer module. `helmholtz_set_methods` is called (usually via `mg_set_methods` in `m_multigrid` when `mg%operator_type` is `mg_helmholtz`) to register `box_helmh` as `mg%box_op` and `box_gs_helmh` as `mg%box_smoother`. The generic multigrid cycling routines (`mg_fas_fmg`, `mg_fas_vcycle`) then invoke these procedure pointers.
+  - **`m_ghost_cells`:** Before the multigrid cycle calls the operator (`box_helmh`) or the smoother (`box_gs_helmh`), routines from `m_ghost_cells` must be called to ensure that ghost cells for the relevant variables (typically `mg_iphi` and `mg_irhs`) are correctly filled with data from neighboring boxes or physical boundary conditions.
+  - **Application Modules (e.g., `m_diffusion`):** Higher-level modules that solve specific physical problems (like time-dependent diffusion) might use `m_helmholtz` as a sub-step. For instance, an implicit time step for a diffusion equation $u_t = D \nabla^2 u$ can be rearranged into a Helmholtz equation for $u^{n+1}$. Such modules would call `helmholtz_set_lambda` and `helmholtz_set_methods` (or `mg_set_methods`) appropriately.
+
+## Usage Examples
+
+```fortran
+! Conceptual Example: Configuring the multigrid solver for a Helmholtz problem.
+
+use m_data_structures
+use m_helmholtz
+use m_multigrid      ! For the generic mg_set_methods, though direct call is also possible.
+
+implicit none
+
+type(mg_t) :: my_mg_problem
+real(dp)   :: desired_lambda
+
+! 1. Initialize the multigrid structure (details omitted for brevity)
+!    This includes defining the grid, MPI settings, etc.
+!    call setup_basic_mg_structure(my_mg_problem)
+my_mg_problem%geometry_type = mg_cartesian
+my_mg_problem%smoother_type = mg_smoother_gsrb ! e.g., Red-Black Gauss-Seidel
+
+! 2. Specify that the problem is a Helmholtz type
+my_mg_problem%operator_type = mg_helmholtz
+
+! 3. Set the Helmholtz lambda parameter
+desired_lambda = 5.0_dp
+call helmholtz_set_lambda(desired_lambda)
+
+! 4. Associate the Helmholtz operator and smoother with the mg_t object.
+!    This can be done by directly calling the module's set_methods:
+!    call helmholtz_set_methods(my_mg_problem)
+!    Or, more commonly, by calling the generic dispatcher in m_multigrid
+!    if mg_operator_type is already set to mg_helmholtz:
+call mg_set_methods(my_mg_problem)
+
+! Now, 'my_mg_problem' is configured. When multigrid routines like
+! mg_fas_fmg(my_mg_problem, ...) or mg_smooth(my_mg_problem, ...) are called,
+! they will use the 'box_helmh' for operator applications and
+! 'box_gs_helmh' for smoothing, with the specified 'helmholtz_lambda'.
+
+! Inside a multigrid cycle (conceptual flow):
+! integer :: some_box_id, cells_in_box, target_var_index, rb_counter
+! ...
+! ! Ghost cells for mg_iphi and mg_irhs would be filled here for relevant levels
+! ! call mg_fill_ghost_cells_lvl(my_mg_problem, current_level, mg_iphi)
+! ! call mg_fill_ghost_cells_lvl(my_mg_problem, current_level, mg_irhs)
+!
+! ! Operator application (e.g. to compute residual L(phi) - f )
+! ! This call would resolve to box_helmh(...)
+! call my_mg_problem%box_op(my_mg_problem, some_box_id, cells_in_box, target_var_index)
+!
+! ! Smoothing step
+! ! This call would resolve to box_gs_helmh(...)
+! call my_mg_problem%box_smoother(my_mg_problem, some_box_id, cells_in_box, rb_counter)
+! ...
+```

--- a/docs/src/doc_m_laplacian.f90.md
+++ b/docs/src/doc_m_laplacian.f90.md
@@ -1,0 +1,120 @@
+# `m_laplacian.f90`
+
+## Overview
+
+The `m_laplacian` module is dedicated to implementing the Laplacian operator ($\nabla^2 \phi$ or $\Delta \phi$) and associated smoother routines for use within the `m_octree_mg` multigrid library. The Laplacian is a fundamental elliptic differential operator that appears in numerous partial differential equations (PDEs), most prominently in Poisson's equation ($\nabla^2 \phi = f$) and as the spatial component of heat (diffusion) and wave equations. This module provides discretizations for Cartesian coordinates (in 1D, 2D, and 3D) and for 2D Cylindrical coordinates $(r,z)$.
+
+## Key Components
+
+### Modules
+
+- **`m_laplacian`:** Contains the subroutines for setting up and applying the Laplacian operator and its smoother.
+
+### Functions/Subroutines
+
+- **`laplacian_set_methods(mg)`:**
+  - **Description:** This public subroutine configures the multigrid structure `mg` (of type `mg_t`) to use the appropriate Laplacian operator and smoother based on the `mg%geometry_type`.
+    - If `mg%geometry_type` is `mg_cartesian`:
+      - `mg%box_op` (the operator application procedure pointer) is set to `box_lpl`.
+      - `mg%box_smoother` (the smoother procedure pointer) is set to `box_gs_lpl` (supporting both standard Gauss-Seidel and Red-Black Gauss-Seidel via `mg%smoother_type`).
+    - If `mg%geometry_type` is `mg_cylindrical` (and `NDIM == 2`):
+      - `mg%box_op` is set to `box_clpl`.
+      - `mg%box_smoother` is set to `box_gs_clpl`.
+    - For fully periodic problems in Cartesian coordinates (`all(mg%periodic)` is true), it sets `mg%subtract_mean = .true.`. This flag indicates to the solver that the mean of the solution and RHS should be handled appropriately to ensure a unique solution.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure to be configured.
+
+### Private Module Procedures (Core Operations)
+
+**For Cartesian Coordinates:**
+- **`box_lpl(mg, id, nc, i_out)`:**
+  - **Description:** Applies the discretized Cartesian Laplacian operator ($\nabla^2\phi$) to the variable stored at index `mg_iphi` within the computational box `id`. The result is stored in the `cc(..., i_out)` component of the box's data array. It uses a standard 3, 5, or 7-point stencil for 1D, 2D, or 3D respectively, based on second-order central differences.
+  - **Arguments:** (Standard signature for `mg_box_op`)
+    - `mg (type(mg_t), intent(inout))`, `id (integer, intent(in))`, `nc (integer, intent(in))`, `i_out (integer, intent(in))`.
+
+- **`box_gs_lpl(mg, id, nc, redblack_cntr)`:**
+  - **Description:** Performs a Gauss-Seidel relaxation sweep (either standard or Red-Black, depending on `mg%smoother_type`) for the Poisson equation ($\nabla^2\phi = f$) on the data within box `id`. It updates `mg%boxes(id)%cc(..., mg_iphi)` using values from neighboring cells and the source term `mg%boxes(id)%cc(..., mg_irhs)`.
+  - **Arguments:** (Standard signature for `mg_box_gsrb`)
+    - `mg (type(mg_t), intent(inout))`, `id (integer, intent(in))`, `nc (integer, intent(in))`, `redblack_cntr (integer, intent(in))`.
+
+**For 2D Cylindrical Coordinates $(r,z)$ (if `NDIM == 2`):**
+- **`box_clpl(mg, id, nc, i_out)`:**
+  - **Description:** Applies the 2D cylindrical Laplacian operator $\frac{1}{r}\frac{\partial}{\partial r}\left(r\frac{\partial\phi}{\partial r}\right) + \frac{\partial^2\phi}{\partial z^2}$ to the variable `mg_iphi` in box `id`. The radial coordinate $r$ is assumed to be the first dimension, and $z$ the second.
+  - **Arguments:** (Standard signature for `mg_box_op`).
+
+- **`box_gs_clpl(mg, id, nc, redblack_cntr)`:**
+  - **Description:** Performs Gauss-Seidel relaxation for the 2D cylindrical Poisson equation on box `id`.
+  - **Arguments:** (Standard signature for `mg_box_gsrb`).
+
+## Important Variables/Constants
+
+- **Discretization:** The module uses standard second-order central finite difference approximations for all derivatives.
+- **Cartesian Smoother Factor:** In `box_gs_lpl`, `fac = 0.5_dp / sum(idr2)` is the reciprocal of the sum of diagonal coefficients ($2 \sum 1/dr_i^2$), used in the Gauss-Seidel update.
+- **Cylindrical Coefficients:** `box_clpl` and `box_gs_clpl` use `r_face` (radial position of cell faces) and `r_inv` (inverse of radial cell center positions) to correctly implement the $1/r \cdot \partial/\partial r (r \cdot \partial\phi/\partial r)$ term.
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Crucial for the definitions of `type(mg_t)`, `type(mg_box_t)`, the precision kind `dp`, `NDIM`, variable indices (`mg_iphi`, `mg_irhs`), geometry type constants (`mg_cartesian`, `mg_cylindrical`), and smoother type constants (`mg_smoother_gs`, `mg_smoother_gsrb`).
+- **External Libraries:**
+  - **`cpp_macros.h`:** Used for conditional compilation based on `NDIM` to provide dimension-specific stencil implementations.
+- **Interactions with Other Components:**
+  - **`m_multigrid`:** The primary interaction point. `laplacian_set_methods` is typically called by `mg_set_methods` (in `m_multigrid`) when `mg%operator_type` is `mg_laplacian`. This registers the appropriate `box_..._lpl` or `box_..._clpl` routines as the active operator (`mg%box_op`) and smoother (`mg%box_smoother`). The main multigrid algorithms (`mg_fas_fmg`, `mg_fas_vcycle`) then use these procedure pointers.
+  - **`m_ghost_cells`:** Before any operator application or smoothing sweep performed by this module's routines, ghost cells for the relevant variables (primarily `mg_iphi` for the operator, and both `mg_iphi` and `mg_irhs` for the smoother) must be filled. This is handled by calls to routines in `m_ghost_cells`.
+  - **Application Context:** This module is fundamental when solving Poisson's equation or any PDE involving a Laplacian term. Higher-level modules or the main application driver would configure `mg_t` to use this Laplacian operator.
+
+## Usage Examples
+
+```fortran
+! Conceptual Example: Setting up the multigrid solver for a Poisson problem
+! using the Cartesian Laplacian.
+
+use m_data_structures
+use m_laplacian
+use m_multigrid      ! For the generic mg_set_methods
+
+implicit none
+
+type(mg_t) :: my_poisson_problem
+
+! 1. Initialize the multigrid structure (grid parameters, MPI setup, etc.)
+!    (Details omitted for brevity - this is a complex step involving other modules)
+!    call comprehensive_mg_initialization(my_poisson_problem)
+
+! 2. Specify the problem type and geometry for the solver
+my_poisson_problem%operator_type = mg_laplacian  ! Indicate a Laplacian-based problem
+my_poisson_problem%geometry_type = mg_cartesian  ! Use Cartesian coordinates
+my_poisson_problem%smoother_type = mg_smoother_gsrb ! Select Red-Black Gauss-Seidel
+
+! 3. Associate the Laplacian operator and smoother with the mg_t object.
+!    This is typically done via the generic mg_set_methods from m_multigrid,
+!    which will dispatch to laplacian_set_methods based on operator_type.
+call mg_set_methods(my_poisson_problem)
+
+! Now, 'my_poisson_problem' is configured to use the Cartesian Laplacian.
+! When multigrid routines (e.g., mg_fas_fmg, mg_fas_vcycle, mg_smooth) are
+! called with 'my_poisson_problem', they will internally use:
+! - 'box_lpl' for applying the Laplacian operator (e.g., in residual calculation).
+! - 'box_gs_lpl' for smoothing steps.
+
+! If solving a 2D problem in cylindrical coordinates:
+#if NDIM == 2
+! my_poisson_problem%geometry_type = mg_cylindrical
+! call mg_set_methods(my_poisson_problem) ! This would set up box_clpl and box_gs_clpl
+#endif
+
+! Inside a multigrid cycle (conceptual flow, managed by m_multigrid routines):
+! integer :: some_box_id, cells_per_side, output_idx, rb_iter_count
+! ...
+! ! Ensure ghost cells are up-to-date for the current level and variable mg_iphi
+! ! call mg_fill_ghost_cells_lvl(my_poisson_problem, current_lvl, mg_iphi)
+!
+! ! Apply Laplacian operator (e.g. L(phi) stored in output_idx)
+! ! This call would resolve to box_lpl(...) or box_clpl(...)
+! call my_poisson_problem%box_op(my_poisson_problem, some_box_id, cells_per_side, output_idx)
+!
+! ! Apply smoother
+! ! This call would resolve to box_gs_lpl(...) or box_gs_clpl(...)
+! call my_poisson_problem%box_smoother(my_poisson_problem, some_box_id, cells_per_side, rb_iter_count)
+! ...
+```

--- a/docs/src/doc_m_load_balance.f90.md
+++ b/docs/src/doc_m_load_balance.f90.md
@@ -1,0 +1,114 @@
+# `m_load_balance.f90`
+
+## Overview
+
+The `m_load_balance` module in the `m_octree_mg` library is dedicated to distributing the computational workload—represented by the individual grid boxes of the octree/quadtree structure—among the available MPI processes. The goal of load balancing is to ensure that each process receives a roughly equal share of the computational effort, which is critical for achieving good parallel efficiency and scalability. This module does not transfer the actual box data (`cc` arrays) but rather assigns an owner MPI rank (`mg%boxes(id)%rank`) to each box `id`. Subsequent operations, like memory allocation (`m_allocate_storage`) and computations, then use this rank information to operate only on locally owned boxes. The overall tree structure (connectivity) is assumed to be known by all processes.
+
+## Key Components
+
+### Modules
+
+- **`m_load_balance`:** Provides different strategies for assigning MPI ranks to grid boxes.
+
+### Functions/Subroutines
+
+- **`mg_load_balance_simple(mg)`:**
+  - **Description:** Implements a straightforward load balancing scheme.
+    1.  Boxes on very coarse levels (at or below `single_cpu_lvl`, which is derived from `mg%first_normal_lvl` and `mg%lowest_lvl` where box sizes might not be uniform for standard communication) are assigned to rank 0.
+    2.  For finer levels, it distributes contiguous blocks of boxes on each level as evenly as possible across the MPI ranks. The distribution relies on the Morton-like ordering of box IDs within `mg%lvls(lvl)%ids` that results from the tree construction process.
+    This method is noted to be most effective for grids that are largely uniform. After assigning ranks, it calls `update_lvl_info` for each level.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure whose `mg%boxes(:)%rank` fields will be updated.
+
+- **`mg_load_balance(mg)`:**
+  - **Description:** A more refined load balancing strategy that attempts to keep parent boxes on the same rank as the majority of their children.
+    1.  It iterates from the finest level (`mg%highest_lvl`) down to `single_cpu_lvl + 1`.
+    2.  On each level, it first assigns ranks to parent boxes: a parent is assigned to the rank that owns the most of its children (using `most_popular` to break ties by favoring ranks with less current work).
+    3.  Then, it distributes the leaf boxes on that level to balance the remaining workload among MPI ranks, considering the work already assigned via parent boxes.
+    4.  Boxes on levels at or below `single_cpu_lvl` are assigned to a single `coarse_rank`, which is determined by the most prevalent rank on the `single_cpu_lvl + 1` level.
+    After assigning ranks, it calls `update_lvl_info` for each level.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+
+- **`mg_load_balance_parents(mg)`:**
+  - **Description:** This routine is designed for scenarios where the ranks of leaf boxes have already been determined by some other mechanism (e.g., application-specific criteria or a previous load balancing step). It then focuses on assigning ranks to the parent (non-leaf) boxes.
+    1.  It iterates from `mg%highest_lvl - 1` down to `single_cpu_lvl + 1`.
+    2.  For each parent box on a given level, it assigns the rank that owns the majority of its children, using `most_popular` to break ties based on the existing workload (which includes the pre-assigned leaf ranks and already processed parent ranks).
+    3.  Boxes on levels at or below `single_cpu_lvl` are assigned to a `coarse_rank` determined by the most prevalent rank on `single_cpu_lvl + 1`.
+    After assigning ranks, it calls `update_lvl_info` for each level.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+
+### Private Helper Subroutines
+
+- **`most_popular(list, work, n_cpu) pure integer function`:**
+  - **Description:** Identifies the most frequently occurring MPI rank in the input integer `list(:)`. If there's a tie in frequency, it selects the rank among the tied ones that currently has the minimum `work` assigned (from the `work(0:n_cpu-1)` array).
+  - **Arguments:** `list (integer, intent(in), :)`, `work (integer, intent(in), array)`, `n_cpu (integer, intent(in))`.
+
+- **`update_lvl_info(mg, lvl)`:**
+  - **Description:** After the `mg%boxes(:)%rank` assignments are finalized by one of the load balancing routines, this subroutine updates the per-process lists within the `mg%lvls(lvl)` structure. Specifically, for the current MPI process (identified by `mg%my_rank`), it populates:
+    - `lvl%my_ids`: List of all box IDs on this `lvl` owned by the current process.
+    - `lvl%my_leaves`: List of leaf box IDs on this `lvl` owned by the current process.
+    - `lvl%my_parents`: List of parent box IDs on this `lvl` owned by the current process.
+    - `lvl%my_ref_bnds`: List of refinement boundary box IDs on this `lvl` owned by the current process.
+  - **Arguments:** `mg (type(mg_t), intent(inout))`, `lvl (type(mg_lvl_t), intent(inout))`.
+
+## Important Variables/Constants
+
+- **`mg%boxes(id)%rank (integer)`:** The primary output of this module; stores the MPI rank assigned to own box `id`.
+- **`single_cpu_lvl (integer, local variable)`:** Calculated as `max(mg%first_normal_lvl-1, mg%lowest_lvl)`. Boxes on levels at or below `single_cpu_lvl` are typically assigned to a single MPI rank (often rank 0) because they might have varying box sizes not suitable for standard distributed communication patterns or represent too little computational work to be worth distributing.
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Absolutely fundamental. This module extensively uses `type(mg_t)`, `type(mg_box_t)`, and `type(mg_lvl_t)` and their members, including `rank`, `ids`, `leaves`, `parents`, `children`, `my_ids`, `first_normal_lvl`, `lowest_lvl`, `highest_lvl`, `n_cpu`, and `my_rank`.
+- **External Libraries:**
+  - None are directly invoked for MPI communication within this module's subroutines, but the logic is entirely built around an MPI-parallel environment defined by `mg%n_cpu` and `mg%my_rank`.
+- **Interactions with Other Components:**
+  - **`m_build_tree`:** Load balancing routines are typically called after the grid tree has been initially constructed by `m_build_tree` (which usually assigns all boxes to rank 0 by default) or after any significant structural changes to the tree (e.g., due to adaptive mesh refinement, though AMR is not explicitly detailed in `m_build_tree`).
+  - **`m_allocate_storage`:** This module is called *after* load balancing. `m_allocate_storage` uses the `mg%boxes(id)%rank` assignments to allocate memory for the actual cell-centered data arrays (`mg%boxes(id)%cc`) only for those boxes assigned to the current MPI process (`mg%my_rank`).
+  - **Communication Modules (e.g., `m_ghost_cells`, `m_restrict`, `m_prolong`, `m_communication`):** All inter-process communication routines rely on the `mg%boxes(id)%rank` field to determine if data needs to be sent to or received from another process, or if a neighboring box is local.
+  - **Adaptive Mesh Refinement (AMR) Systems:** If the application employs AMR, strategies like `mg_load_balance_parents` become particularly important to re-balance the parent nodes after the distribution of leaf nodes changes due to refinement or coarsening.
+
+## Usage Examples
+
+```fortran
+! Conceptual Example: Performing load balancing after tree construction.
+
+use m_data_structures
+use m_build_tree     ! For tree creation (assumed to be called prior)
+use m_load_balance
+use m_allocate_storage ! Typically called after load balancing
+
+implicit none
+
+type(mg_t) :: my_multigrid_config
+
+! 1. Initialize the multigrid configuration and build the tree structure.
+!    (This is a complex process involving other modules; mg_build_rectangle
+!    usually assigns all boxes to rank 0 initially).
+!    call initialize_and_build_tree(my_multigrid_config)
+
+! 2. Perform load balancing. Choose one of the available strategies:
+
+!    Strategy A: Simple load balancing (often suitable for uniform grids)
+!    call mg_load_balance_simple(my_multigrid_config)
+
+!    Strategy B: More advanced load balancing (tries to keep children with parents)
+call mg_load_balance(my_multigrid_config)
+
+!    Strategy C: Balance parents assuming leaves are already balanced
+!    (Requires leaf ranks to be set prior to this call by another mechanism)
+!    call mg_load_balance_parents(my_multigrid_config)
+
+! 3. After load balancing, the mg%boxes(:)%rank fields are set, and the
+!    mg%lvls(:)%my_ids, my_leaves, my_parents, my_ref_bnds arrays are populated.
+!    Now, allocate storage for the data arrays of locally owned boxes.
+call mg_allocate_storage(my_multigrid_config)
+
+! The application can now proceed with computations, with each MPI process
+! working on its assigned subset of boxes.
+if (my_multigrid_config%my_rank == 0) then
+    print *, "Load balancing and storage allocation complete."
+end if
+```

--- a/docs/src/doc_m_mrgrnk.f90.md
+++ b/docs/src/doc_m_mrgrnk.f90.md
@@ -1,0 +1,82 @@
+# `m_mrgrnk.f90`
+
+## Overview
+
+The `m_mrgrnk` module provides a sorting utility. Contrary to what its name might initially suggest (e.g., related to MPI ranks), this module implements a "Merge-sort ranking" algorithm for an array of integers. Instead of returning the sorted data directly, it outputs an array of indices (ranks). These indices specify the order of the elements from the original input array if they were to be arranged in ascending sorted order. For example, the first element of the rank array gives the index of the smallest element in the input array, the second element of the rank array gives the index of the second smallest, and so on. This type of ranking is useful when the original positions of elements are important or when multiple arrays need to be sorted based on the keys in one primary array.
+
+## Key Components
+
+### Modules
+
+- **`m_mrgrnk`:** Encapsulates the merge-sort ranking functionality.
+
+### Public Interface/Subroutine
+
+- **`mrgrnk(XDONT, IRNGT)`:**
+  - **Description:** This is the sole public interface provided by the module, which internally calls the `I_mrgrnk` subroutine. It takes an array of integers and returns an array of indices that represent the sort order.
+  - **Arguments:**
+    - `XDONT (integer, dimension(:), intent(in))`: The input array of integer values to be ranked. The name `XDONT` (presumably "X data original not touched") is slightly unconventional for an input array that *is* the data to be sorted by rank.
+    - `IRNGT (integer, dimension(:), intent(out))`: The output array, which will be populated with the 1-based indices of the `XDONT` array in ascending order of their values. For example, `IRNGT(1)` will hold the index `j` such that `XDONT(j)` is the smallest value in `XDONT`. The size of `IRNGT` processed will be `min(size(XDONT), size(IRNGT))`.
+
+### Private Subroutine
+
+- **`I_mrgrnk(XDONT, IRNGT)`:**
+  - **Description:** This is the actual implementation of the merge-sort ranking algorithm. The algorithm works by iteratively merging ordered sub-sequences. The implementation includes specific optimizations for the initial passes (creating ordered couples, then ordered quadruplets) before entering a general loop that doubles the length of ordered subsets in each iteration. It uses an internal work array `JWRKT` (a copy of parts of `IRNGT` during merge steps) to facilitate the merge operations.
+  - **Arguments:** Same as the public `mrgrnk` interface.
+
+## Important Variables/Constants
+
+- **`kdp (integer, parameter, private)`:** Defined as `selected_real_kind(15)`. This constant is declared in the module but is not used within the `I_mrgrnk` subroutine, as the sorting logic is purely for integer arrays. It might be a remnant from a previous version or intended for a different, unincluded routine.
+- **`JWRKT (integer, dimension(SIZE(IRNGT)))` (local in `I_mrgrnk`):** A work array used during the merge phases of the sort to temporarily hold parts of the index array being merged.
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - The module relies only on standard Fortran intrinsic functions like `min`, `size`, and `modulo`.
+- **External Libraries:**
+  - None. This is a self-contained sorting utility.
+- **Interactions with Other Components:**
+  - **`m_communication`:** The `sort_sendbuf` subroutine within `m_communication` uses `mrgrnk` to sort the `gc%ix` array (which likely contains indices or keys for data elements in a send buffer) and then reorders the actual send buffer `gc%send` according to these sorted ranks. This is essential for ensuring that data elements within MPI messages are in a consistent and expected order when received by other processes, especially if they were packed into the buffer in a different order.
+  - **General Utility:** Any other module within the `m_octree_mg` library (or an external application using it) that needs to determine the sorted order of an integer array without modifying the array itself can use `m_mrgrnk`.
+
+## Usage Examples
+
+```fortran
+! Example demonstrating the use of the mrgrnk subroutine.
+
+use m_mrgrnk
+implicit none
+
+integer, dimension(7) :: my_data_array
+integer, dimension(7) :: sorted_indices
+integer :: i
+
+! Initialize data
+my_data_array = [45, 12, 89, 2, 67, 22, 50]
+
+! Call mrgrnk to get the indices that would sort my_data_array
+call mrgrnk(my_data_array, sorted_indices)
+
+! Output the results
+print "(A, 7I4)", "Original Data : ", my_data_array
+print "(A, 7I4)", "Rank Indices  : ", sorted_indices
+
+print *, ""
+print *, "Data elements in sorted order (accessed via sorted_indices):"
+do i = 1, size(my_data_array)
+  print "(I4)", my_data_array(sorted_indices(i))
+end do
+
+! Expected output:
+! Original Data :   45  12  89   2  67  22  50
+! Rank Indices  :    4   2   6   1   7   5   3
+!
+! Data elements in sorted order (accessed via sorted_indices):
+!   2
+!  12
+!  22
+!  45
+!  50
+!  67
+!  89
+```

--- a/docs/src/doc_m_multigrid.f90.md
+++ b/docs/src/doc_m_multigrid.f90.md
@@ -1,0 +1,158 @@
+# `m_multigrid.f90`
+
+## Overview
+
+The `m_multigrid` module is the core engine of the `m_octree_mg` library, implementing the sophisticated Full Approximation Scheme (FAS) multigrid algorithms. Multigrid methods are highly efficient iterative techniques for solving systems of equations arising from the discretization of partial differential equations. This module orchestrates the fundamental multigrid operations:
+
+-   **Smoothing:** Applying a few iterations of a basic iterative solver (e.g., Gauss-Seidel) to damp high-frequency errors on a given grid level.
+-   **Restriction:** Transferring the problem (solution and residual) from a finer grid to a coarser grid.
+-   **Prolongation:** Interpolating a correction computed on a coarser grid back to a finer grid.
+-   **Coarse-Grid Solve:** Solving the problem on the coarsest grid, either directly or with more iterations of the smoother.
+
+It provides implementations for V-cycles and Full Multigrid (FMG) cycles, which combine these operations to achieve rapid convergence. The module is designed to be generic, relying on procedure pointers within the `mg_t` data structure to call specific routines for the PDE operator, smoother, and prolongation method, which are set based on the physics of the problem (e.g., Laplacian, Helmholtz).
+
+## Key Components
+
+### Modules
+
+- **`m_multigrid`:** Contains the implementations of FAS V-cycles, FMG cycles, method dispatching, and helper routines for the multigrid process.
+
+### Functions/Subroutines
+
+- **`mg_set_methods(mg)`:**
+  - **Description:** A dispatcher routine that configures the multigrid structure `mg` with the appropriate operator-specific subroutines. Based on the value of `mg%operator_type` (e.g., `mg_laplacian`, `mg_helmholtz`), it calls the corresponding `xxx_set_methods` subroutine from the relevant operator module (e.g., `m_laplacian%laplacian_set_methods`). These specialized routines then assign the actual Fortran subroutines for operator application (`mg%box_op`), smoothing (`mg%box_smoother`), and potentially prolongation (`mg%box_prolong`) to the procedure pointers in the `mg_t` object. It also sets `mg%n_smoother_substeps` (e.g., 2 for Red-Black Gauss-Seidel).
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure to be configured.
+
+- **`mg_fas_fmg(mg, have_guess, max_res)`:**
+  - **Description:** Implements the Full Multigrid (FMG) cycle using the Full Approximation Scheme (FAS). FMG provides a highly efficient way to obtain a solution by starting on the coarsest grid and progressively solving on finer grids, using the solution from the previous coarser grid as an initial guess.
+    1.  If `have_guess` is `.false.`, the solution `mg_iphi` is initialized to zero on all levels.
+    2.  The problem is restricted down to the `mg%lowest_lvl` by repeatedly calling `update_coarse`.
+    3.  If `mg%subtract_mean` is true (for fully periodic problems), the mean of the source term `mg_irhs` is subtracted.
+    4.  It then iterates from `mg%lowest_lvl` up to `mg%highest_lvl`:
+        a.  The solution from the next coarser level (`lvl-1`) is prolonged to correct the current solution on `lvl` (`correct_children`).
+        b.  A FAS V-cycle (`mg_fas_vcycle`) is performed on `lvl`.
+    5.  Optionally returns the maximum absolute residual `max_res` on the finest level.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid structure.
+    - `have_guess (logical, intent(in))`: If `.true.`, assumes `mg_iphi` contains an initial guess. If `.false.`, `mg_iphi` is initialized to zero.
+    - `max_res (real(dp), intent(out), optional)`: If present, stores the maximum absolute residual on the finest level after the FMG cycle.
+
+- **`mg_fas_vcycle(mg, highest_lvl, max_res, standalone)`:**
+  - **Description:** Implements a single FAS V-cycle. A V-cycle consists of:
+    1.  Pre-smoothing (relaxing) on the current grid (`smooth_boxes`).
+    2.  Computing the residual ($r_f = f_f - L_f \phi_f$).
+    3.  Restricting the residual and the current solution $\phi_f$ to the next coarser grid (`update_coarse`). The coarse grid problem becomes $L_c \phi_c = f_c$, where $f_c = L_c (\text{restrict}(\phi_f)) + \text{restrict}(r_f)$.
+    4.  Recursively calling the V-cycle for the coarse grid problem (or solving directly if on the `mg%lowest_lvl` using more smoothing iterations).
+    5.  Prolonging the computed correction from the coarse grid ($\phi_c^{\text{new}} - \phi_c^{\text{old}}$) and adding it to the fine grid solution (`correct_children`).
+    6.  Post-smoothing on the current grid (`smooth_boxes`).
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid structure.
+    - `highest_lvl (integer, intent(in), optional)`: The finest level for this V-cycle. Defaults to `mg%highest_lvl`.
+    - `max_res (real(dp), intent(out), optional)`: If present, stores the maximum absolute residual on `highest_lvl` after the V-cycle.
+    - `standalone (logical, intent(in), optional)`: If `.true.` (default), timers are started/stopped and initial ghost cells are filled. If `.false.`, these are skipped (used when called from `mg_fas_fmg`).
+
+- **`mg_apply_op(mg, i_out, op)`:**
+  - **Description:** Applies the currently configured multigrid operator (pointed to by `mg%box_op`, or an optionally provided `op`) to the solution variable `mg_iphi`. This is done for all locally owned boxes across all grid levels from `mg%lowest_lvl` to `mg%highest_lvl`. The result of the operator $L(\phi)$ is stored in the variable indexed by `i_out`.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid structure.
+    - `i_out (integer, intent(in))`: The index in the `cc` array where the operator result will be stored.
+    - `op (procedure(mg_box_op), optional)`: An optional specific operator procedure to use instead of `mg%box_op`.
+
+### Private Helper Subroutines (Selected)
+
+- **`check_methods(mg)`:** Ensures `mg%box_op` and `mg%box_smoother` are associated; calls `mg_set_methods` if they are not. This is called at the beginning of `mg_fas_fmg` and `mg_fas_vcycle`.
+- **`mg_add_timers(mg)`:** Initializes various timers (e.g., `timer_total_vcycle`, `timer_smoother`) used for profiling different parts of the multigrid cycles.
+- **`update_coarse(mg, lvl)`:** Key FAS routine. Computes fine-grid residual $r_f = f_f - L_f \phi_f$ (using `residual_box`), restricts $\phi_f$ (to `mg_iphi` on coarse) and $r_f$ (to `mg_ires` on coarse). Then forms the coarse-grid RHS: $f_c = L_c \phi_c + r_c$. Stores the restricted $\phi_f$ into `mg_iold` on the coarse grid for later use in `correct_children`.
+- **`correct_children(mg, lvl)`:** Key FAS routine. Computes the correction term on the coarse grid (`lvl`): $\delta_c = \phi_c^{\text{new}} - \phi_c^{\text{old}}$ (where $\phi_c^{\text{old}}$ is the restricted fine solution from `update_coarse`). This correction $\delta_c$ (stored in `mg_ires` on coarse grid) is then prolonged to the fine grid (`lvl+1`) and added to its solution: $\phi_f^{\text{new}} = \phi_f^{\text{old}} + P(\delta_c)$.
+- **`smooth_boxes(mg, lvl, n_cycle)`:** Performs `n_cycle` smoothing iterations on all locally owned boxes at level `lvl`. Each iteration consists of `mg%n_smoother_substeps` calls to the `mg%box_smoother` procedure, with ghost cell updates (`mg_fill_ghost_cells_lvl`) after each substep.
+- **`residual_box(mg, id, nc)`:** Calculates the residual $r = f - L\phi$ for a single box `id`, storing the result in `mg%boxes(id)%cc(..., mg_ires)`. $L\phi$ is computed using `mg%box_op`.
+- **`subtract_mean(mg, iv, include_ghostcells)`:** For fully periodic boundary conditions, this routine subtracts the global mean of the variable `iv` from itself to ensure a unique solution. Uses `MPI_Allreduce` to compute the global sum.
+- **`max_residual_lvl(mg, lvl)`:** Computes the maximum absolute value of the residual (stored in `mg_ires`) for all locally owned boxes on a given `lvl`.
+
+## Important Variables/Constants
+
+- **Timer Variables (Module-level):** `timer_total_vcycle`, `timer_total_fmg`, `timer_smoother`, `timer_smoother_gc`, `timer_coarse`, `timer_correct`, `timer_update_coarse`. These are handles for timers defined in `m_data_structures`.
+- **Cycle Control Parameters (from `mg_t` type in `m_data_structures`):**
+  - `mg%n_cycle_down`: Number of pre-smoothing steps.
+  - `mg%n_cycle_up`: Number of post-smoothing steps.
+  - `mg%max_coarse_cycles`: Maximum smoother iterations on the coarsest grid.
+  - `mg%residual_coarse_rel`, `mg%residual_coarse_abs`: Relative and absolute tolerances for stopping the coarse grid solve.
+  - `mg%subtract_mean`: Logical flag to enable mean subtraction for fully periodic problems.
+  - `mg%n_smoother_substeps`: Number of sub-steps per smoother application (e.g., 2 for Red-Black Gauss-Seidel).
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Absolutely fundamental. Provides `type(mg_t)` and all its members, including procedure pointers (`box_op`, `box_smoother`, `box_prolong`), variable indices (`mg_iphi`, `mg_irhs`, `mg_iold`, `mg_ires`), and various control flags and parameters.
+  - **`m_prolong`:** Provides the `mg_prolong` routine (used by `correct_children`) and the default prolongation method `mg_prolong_sparse`.
+  - **`m_restrict`:** Provides the `mg_restrict_lvl` routine (used by `update_coarse`).
+  - **`m_ghost_cells`:** Provides `mg_fill_ghost_cells_lvl`, which is called repeatedly within smoothing loops and after correction steps.
+  - **Operator-Specific Modules (e.g., `m_laplacian`, `m_helmholtz`, `m_ahelmholtz`, etc.):** The `mg_set_methods` routine calls the `xxx_set_methods` from these modules to link the actual PDE operator and smoother implementations to the procedure pointers in `mg_t`.
+- **External Libraries:**
+  - **`mpi`:** Used for `MPI_ALLREDUCE` in `mg_fas_vcycle` (for global residual calculation) and in `subtract_mean` (for global sum).
+  - **`cpp_macros.h`:** Used for the `DTIMES` macro for dimension-agnostic array indexing.
+- **Interactions with Other Components:**
+  - This module is the orchestrator of the multigrid solution process. It is typically invoked by higher-level modules or main application drivers that have already set up the specific PDE problem (e.g., `m_diffusion`, `m_poisson_fft`).
+  - It requires a fully initialized `mg_t` structure, including:
+    - A defined grid hierarchy (`m_build_tree`).
+    - Load distribution (`m_load_balance`).
+    - Allocated storage (`m_allocate_storage`).
+    - The specific `operator_type` set.
+    - Boundary conditions defined in `mg%bc`.
+    - The source term $f$ loaded into `mg%boxes(:)%cc(..., mg_irhs)`.
+  - The operator-specific modules provide the "physics" by supplying the discrete operator $L$ and smoother $S$ via procedure pointers. This module then applies them in the sequence defined by the V-cycle or FMG algorithm.
+
+## Usage Examples
+
+```fortran
+! Conceptual Example: Solving a PDE using the FAS FMG cycle.
+
+use m_data_structures
+use m_multigrid
+! Other modules would be needed for full setup:
+! use m_default_settings, use m_build_tree, use m_load_balance,
+! use m_allocate_storage, use m_laplacian (or other operator module)
+
+implicit none
+
+type(mg_t) :: my_pde_problem
+logical    :: has_initial_guess
+real(dp)   :: final_max_residual
+
+! 1. Perform comprehensive setup of 'my_pde_problem':
+!    - Initialize mg_t with default values.
+!    - Set problem-specific parameters (e.g., my_pde_problem%operator_type = mg_laplacian).
+!    - Build the grid tree (e.g., call mg_build_rectangle).
+!    - Distribute load among MPI processes (e.g., call mg_load_balance).
+!    - Allocate memory for grid data (e.g., call mg_allocate_storage).
+!    - Define boundary conditions in my_pde_problem%bc.
+!    - Populate the source term f in my_pde_problem%boxes(:)%cc(..., mg_irhs).
+!    - If an initial guess for the solution is available, populate it in
+!      my_pde_problem%boxes(:)%cc(..., mg_iphi) and set has_initial_guess = .true.
+!    call setup_my_specific_pde_problem(my_pde_problem, has_initial_guess) ! Placeholder
+
+! 2. Ensure operator-specific methods are set.
+!    mg_fas_fmg and mg_fas_vcycle internally call check_methods, which calls
+!    mg_set_methods if needed. So, an explicit call here is often for clarity
+!    or if settings need to be confirmed before the main solve.
+call mg_set_methods(my_pde_problem)
+
+! 3. Solve the PDE using the Full Multigrid (FMG) algorithm.
+call mg_fas_fmg(my_pde_problem, has_initial_guess, final_max_residual)
+
+! The solution is now in my_pde_problem%boxes(:)%cc(..., mg_iphi).
+if (my_pde_problem%my_rank == 0) then
+    print *, "FMG Solution complete. Final maximum residual:", final_max_residual
+end if
+
+! Example of performing an additional V-cycle if needed:
+! call mg_fas_vcycle(my_pde_problem, max_res=final_max_residual)
+! if (my_pde_problem%my_rank == 0) then
+!    print *, "Additional V-cycle. New maximum residual:", final_max_residual
+! end if
+
+! Example of applying the configured operator L to current phi, storing result in mg_ires:
+! call mg_apply_op(my_pde_problem, mg_ires)
+! This would compute L(phi) and place it into the mg_ires field of each box's cc array.
+```

--- a/docs/src/doc_m_octree_mg.f90.md
+++ b/docs/src/doc_m_octree_mg.f90.md
@@ -1,0 +1,107 @@
+# `m_octree_mg.f90`
+
+## Overview
+
+The `m_octree_mg` module serves as the primary public interface and an "umbrella" module for the entire octree-mg library. Its main purpose is to simplify the integration and usage of the library in user applications. By using a single `use m_octree_mg` statement, developers gain access to the vast majority of the public entities—derived types, subroutines, functions, and named constants—from all the core functional modules of the library. This approach abstracts away the need for the user to individually `use` each specific `m_...` component module (like `m_data_structures`, `m_multigrid`, `m_build_tree`, etc.), thereby providing a more convenient and cleaner way to incorporate the octree-mg functionalities into their code.
+
+## Key Components
+
+### Modules
+
+- **`m_octree_mg`:** This module itself. Its primary content is a series of `use` statements.
+
+### Re-exported Modules and Entities
+
+The `m_octree_mg` module uses the following specialized modules from the library. Due to the `public` attribute declared in `m_octree_mg` without an `only` clause, all public entities from these used modules are effectively re-exported and become available to any program unit that `use`s `m_octree_mg`.
+
+The key modules included are:
+-   **`m_data_structures`:** Provides all fundamental derived data types (e.g., `mg_t`, `mg_box_t`, `mg_lvl_t`), named constants for variable indices (e.g., `mg_iphi`, `mg_irhs`), operator types, boundary condition types, etc.
+-   **`m_build_tree`:** Contains subroutines for constructing the octree or quadtree grid hierarchy (e.g., `mg_build_rectangle`).
+-   **`m_load_balance`:** Includes routines for distributing the computational grid boxes among MPI processes (e.g., `mg_load_balance`).
+-   **`m_ghost_cells`:** Manages the filling of ghost cell data, essential for parallel computations and applying boundary conditions (e.g., `mg_fill_ghost_cells_lvl`).
+-   **`m_allocate_storage`:** Provides routines for allocating and deallocating memory for the grid data arrays (e.g., `mg_allocate_storage`, `mg_deallocate_storage`).
+-   **`m_restrict`:** Contains subroutines for restriction operations (transferring data from finer to coarser grids, e.g., `mg_restrict_lvl`).
+-   **`m_communication`:** Handles low-level MPI communication tasks, such as initializing MPI and transferring data buffers (e.g., `mg_comm_init`, `sort_and_transfer_buffers`).
+-   **`m_prolong`:** Includes subroutines for prolongation operations (interpolating data from coarser to finer grids, e.g., `mg_prolong`).
+-   **`m_multigrid`:** The core module implementing the multigrid solver algorithms like Full Approximation Scheme (FAS) V-cycles and FMG cycles (e.g., `mg_fas_vcycle`, `mg_fas_fmg`, `mg_set_methods`).
+-   **`m_helmholtz`:** Implements the constant-coefficient Helmholtz operator and smoother (e.g., `helmholtz_set_lambda`).
+-   **`m_vhelmholtz`:** Implements the variable-coefficient Helmholtz operator and smoother.
+-   **`m_ahelmholtz`:** Implements the anisotropic-coefficient Helmholtz operator and smoother.
+-   **`m_free_space`:** Provides a solver for 3D Poisson problems with free-space boundary conditions (e.g., `mg_poisson_free_3d`).
+
+The `implicit none` statement is used, and then `public` makes all entities from the used modules available.
+
+## Important Variables/Constants
+
+This module does not define any new variables or constants itself. All such entities are inherited from the modules it `use`s, with `m_data_structures` being the primary source of named constants and data types.
+
+## Dependencies and Interactions
+
+-   **Primary Role as a Dependency Aggregator:** The `m_octree_mg` module's main function is to establish dependencies on nearly all other key modules within the octree-mg library.
+-   **User Interaction:** This module is intended to be the main point of entry for users of the octree-mg library. By including `use m_octree_mg` in their application code, users can conveniently access the library's comprehensive suite of tools for multigrid simulations without needing to manage a long list of individual `use` statements for each component.
+
+## Usage Examples
+
+The following conceptual example illustrates how an end-user's application might leverage `m_octree_mg` to set up and solve a partial differential equation using the library's multigrid framework.
+
+```fortran
+! Example: A user's application program solving a PDE using the octree-mg library.
+
+program my_pde_solver_application
+  use m_octree_mg  ! Single 'use' statement provides access to the library's features.
+  implicit none
+
+  type(mg_t) :: solver_instance  ! mg_t type from m_data_structures, via m_octree_mg
+  real(dp)   :: final_residual
+  logical    :: has_initial_guess
+  integer    :: ierr ! For MPI calls if any are direct
+
+  ! 1. Initialize MPI environment and populate basic MPI info in solver_instance
+  !    (mg_comm_init is from m_communication, available via m_octree_mg)
+  call mg_comm_init(solver_instance)
+
+  ! 2. Configure problem parameters (operator, geometry, etc.)
+  !    (Constants like mg_laplacian are from m_data_structures)
+  solver_instance%operator_type = mg_laplacian
+  solver_instance%geometry_type = mg_cartesian
+  ! ... (Other necessary initializations for domain size, box size, etc.)
+
+  ! 3. Build the grid hierarchy
+  !    (mg_build_rectangle is from m_build_tree)
+  ! call mg_build_rectangle(solver_instance, domain_def, box_def, ...) ! Placeholder for actual args
+
+  ! 4. Distribute grid boxes among MPI processes
+  !    (mg_load_balance is from m_load_balance)
+  call mg_load_balance(solver_instance)
+
+  ! 5. Allocate memory for the cell-centered data arrays
+  !    (mg_allocate_storage is from m_allocate_storage)
+  call mg_allocate_storage(solver_instance)
+
+  ! 6. Define boundary conditions and set initial/source terms
+  !    (Accessing solver_instance%boxes(:)%cc and using constants like mg_iphi, mg_irhs)
+  !    call setup_boundary_conditions_and_rhs(solver_instance) ! Placeholder
+
+  ! 7. Set up the multigrid operator and smoother methods
+  !    (mg_set_methods is from m_multigrid)
+  call mg_set_methods(solver_instance)
+
+  ! 8. Solve the system using a Full Multigrid (FMG) cycle
+  !    (mg_fas_fmg is from m_multigrid)
+  has_initial_guess = .false. ! Example: start from a zero initial solution
+  call mg_fas_fmg(solver_instance, has_initial_guess, final_residual)
+
+  if (solver_instance%my_rank == 0) then
+    print *, "PDE solution complete. Final residual:", final_residual
+  end if
+
+  ! 9. Deallocate storage for grid data arrays
+  !    (mg_deallocate_storage is from m_allocate_storage)
+  call mg_deallocate_storage(solver_instance)
+
+  ! 10. Finalize MPI environment (if initialized by this program/library)
+  ! call MPI_Finalize(ierr) ! Direct MPI call
+
+end program my_pde_solver_application
+```
+This example demonstrates that by simply `use m_octree_mg`, the application program gains access to necessary derived types (`mg_t`), subroutines from various modules (`mg_comm_init`, `mg_build_rectangle`, `mg_load_balance`, `mg_allocate_storage`, `mg_set_methods`, `mg_fas_fmg`, `mg_deallocate_storage`), and constants (`mg_laplacian`, `mg_cartesian`, `mg_iphi`, `mg_irhs`, `dp`). This greatly simplifies the user's code.

--- a/docs/src/doc_m_prolong.f90.md
+++ b/docs/src/doc_m_prolong.f90.md
@@ -1,0 +1,116 @@
+# `m_prolong.f90`
+
+## Overview
+
+The `m_prolong` module is a core component of the `m_octree_mg` multigrid library, responsible for the prolongation operation, also commonly known as interpolation. In the context of multigrid methods, prolongation is the process of transferring data (typically a correction computed on a coarser grid) to a finer grid. This interpolated correction is then used to update the solution on the finer grid. This module provides the necessary routines to perform this interpolation, including handling the communication required when the coarse grid box and its corresponding fine grid children reside on different MPI processes.
+
+## Key Components
+
+### Modules
+
+- **`m_prolong`:** Contains subroutines for calculating prolongation communication buffer sizes, the main prolongation driver, and specific interpolation methods.
+
+### Functions/Subroutines
+
+- **`mg_prolong_buffer_size(mg, n_send, n_recv, dsize)`:**
+  - **Description:** Calculates the required MPI communication buffer sizes for data exchange during prolongation operations. It appears to derive these sizes from the communication patterns already established for restriction operations (`mg%comm_restrict`), as prolongation often involves communication with the same set of processes but in the reverse direction (coarse-to-fine vs. fine-to-coarse). The `dsize` is based on the number of cells in a fine grid box, as fine grid data (after interpolation on the coarse data owner's side) is sent.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure. Buffer needs are stored in `mg%comm_prolong`.
+    - `n_send (integer, intent(out), array)`: Maximum number of items to be sent by the current process.
+    - `n_recv (integer, intent(out), array)`: Maximum number of items to be received by the current process.
+    - `dsize (integer, intent(out))`: Size of a single data element being transferred (number of cells in a fine box: `mg%box_size**NDIM`).
+
+- **`mg_prolong(mg, lvl, iv, iv_to, method, add)`:**
+  - **Description:** This is the main public routine for performing prolongation. It transfers data from variable `iv` on the coarse grid level `lvl` to variable `iv_to` on the fine grid level `lvl+1`.
+    1.  For levels requiring communication (`lvl >= mg%first_normal_lvl-1`), it iterates through locally owned coarse boxes. If a child box on the fine level belongs to a different MPI rank, `prolong_set_buffer` is called to perform the interpolation (using `method`) and pack the result into a send buffer.
+    2.  It then calls `sort_and_transfer_buffers` (from `m_communication`) to execute the MPI data exchange.
+    3.  Finally, it iterates through locally owned fine boxes on level `lvl+1`. `prolong_onto` is called for each, which either uses locally available parent data or data from the receive buffer to perform the interpolation (via `method`) and update the `iv_to` variable.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `lvl (integer, intent(in))`: The coarse grid level to prolong from.
+    - `iv (integer, intent(in))`: Index of the source variable on the coarse grid.
+    - `iv_to (integer, intent(in))`: Index of the target variable on the fine grid.
+    - `method (procedure(mg_box_prolong))`: The specific prolongation/interpolation procedure to be used (e.g., `mg_prolong_sparse`).
+    - `add (logical, intent(in))`: If `.true.`, the prolonged value is added to the existing value in `iv_to` on the fine grid. If `.false.`, it overwrites it. (Adding is typical for FAS corrections).
+
+- **`mg_prolong_sparse(mg, p_id, dix, nc, iv, fine)`:**
+  - **Description:** A specific public prolongation method that implements multilinear interpolation (linear in 1D, bilinear in 2D, trilinear in 3D). It interpolates data from a coarse parent box `p_id` (variable `iv`) to a single fine child box, whose position relative to the parent is given by the logical offset `dix` (identifying which of the $2^{NDIM}$ children it is). The interpolated values for the child box (of size `nc`) are returned in the `fine` array. This is often the default prolongation method assigned to `mg%box_prolong`.
+  - **Arguments:** (Standard signature for `mg_box_prolong` procedure pointer)
+    - `mg (type(mg_t), intent(inout))`: Multigrid structure.
+    - `p_id (integer, intent(in))`: ID of the parent (coarse) box.
+    - `dix(NDIM) (integer, intent(in))`: Logical index offset of the child within the parent's grid structure (e.g., `[0,0]` for the first child in 2D, assuming 0-based indexing for offsets).
+    - `nc (integer, intent(in))`: Size of the child (fine) box.
+    - `iv (integer, intent(in))`: Index of the variable to prolong from the coarse box.
+    - `fine (real(dp), intent(out), array)`: Output array to store the interpolated values for the fine child box. Its dimensions depend on `nc` and `NDIM`.
+
+### Private Helper Subroutines
+
+- **`prolong_set_buffer(mg, id, nc, iv, method)`:**
+  - **Description:** If any children of the coarse box `id` reside on different MPI ranks, this routine calls the specified `method` (e.g., `mg_prolong_sparse`) to compute the interpolated data for those remote children. The resulting fine grid data is then packed into the appropriate send buffer in `mg%buf(child_rank)%send`.
+- **`prolong_onto(mg, id, nc, iv, iv_to, add, method)`:**
+  - **Description:** For a given fine grid box `id`, this routine orchestrates the actual interpolation. It determines if its parent box `p_id` is local or remote. If local, it calls `method` directly. If remote, it unpacks the previously received interpolated data from `mg%buf(parent_rank)%recv`. The result is then either added to or assigned to `mg%boxes(id)%cc(..., iv_to)`.
+
+## Important Variables/Constants
+
+- **Interpolation Stencils:** The `mg_prolong_sparse` routine uses hardcoded weights for multilinear interpolation. For example, in 1D, it uses weights of `0.75` and `0.25` (effectively $(c_i + c_{i-1})/2$ and $(c_i + c_{i+1})/2$ for cell centers if $c_i$ is a cell center, but adapted for cell-to-cell interpolation). Similar fixed coefficient patterns are used for 2D (bilinear) and 3D (trilinear) interpolation.
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Essential for `type(mg_t)`, `type(mg_box_t)`, `type(mg_lvl_t)`, the precision kind `dp`, `NDIM`, constants like `mg_num_children`, and utility functions like `mg_get_child_offset`.
+  - **`m_communication`:** Relies on the `sort_and_transfer_buffers` subroutine from this module to perform the actual MPI exchange of interpolated fine-grid data when needed.
+- **External Libraries:**
+  - **`cpp_macros.h`:** Used for `DTIMES` (dimension-agnostic array slicing) and `NDIM`-dependent conditional compilation of interpolation stencils.
+- **Interactions with Other Components:**
+  - **`m_multigrid`:** This is a primary interaction. The `mg_prolong` routine (or more accurately, a specific method like `mg_prolong_sparse` that is assigned to the `mg%box_prolong` procedure pointer) is invoked by the `correct_children` subroutine within the FAS V-cycle and FMG algorithms. This step applies the coarse-grid correction to the fine grid.
+  - **`m_allocate_storage` (indirectly):** The `mg_prolong_buffer_size` routine is called during the library's setup phase (likely by `m_allocate_storage` or a similar top-level initialization routine that pre-calculates all buffer needs) to determine the maximum buffer sizes required for prolongation data exchange.
+  - **`m_ghost_cells`:** After data is prolonged to a fine level and corrections are applied, the ghost cells for that fine level typically need to be updated (using routines from `m_ghost_cells`) before subsequent operations like smoothing can be performed correctly.
+
+## Usage Examples
+
+Prolongation is mostly an internal operation within the multigrid cycles. Users typically don't call `mg_prolong` directly but rely on it being called by `mg_fas_vcycle` or `mg_fas_fmg`.
+
+```fortran
+! Conceptual Example: How prolongation is invoked within m_multigrid's correct_children.
+
+! In m_multigrid, within a routine like correct_children(mg, coarse_lvl):
+! ...
+! ! Assume 'mg' is type(mg_t)
+! ! 'coarse_lvl' is the current coarse level index.
+! ! The correction term (phi_coarse_new - phi_coarse_old) has been computed and
+! ! is stored in the 'mg_ires' field of the coarse grid boxes on 'coarse_lvl'.
+!
+! ! The goal is to prolong this correction from 'mg_ires' on 'coarse_lvl'
+! ! and add it to 'mg_iphi' on the fine level ('coarse_lvl + 1').
+!
+! if (coarse_lvl < mg%highest_lvl) then
+!   ! mg%box_prolong would point to a specific method like mg_prolong_sparse
+!   call mg_prolong(mg, coarse_lvl, mg_ires, mg_iphi, &
+!                   mg%box_prolong, add=.true.)
+!
+!   ! Following this, m_multigrid would typically fill ghost cells for mg_iphi
+!   ! on level 'coarse_lvl + 1'.
+!   ! call mg_fill_ghost_cells_lvl(mg, coarse_lvl + 1, mg_iphi)
+! end if
+! ...
+
+! The default prolongation method mg_prolong_sparse can also be called directly
+! if needed for specific purposes, though this is less common for end-users:
+use m_data_structures
+use m_prolong
+
+type(mg_t) :: mg_instance
+integer    :: parent_box_id, child_offset(1), fine_box_size, variable_index
+real(dp), allocatable :: interpolated_data_for_child(:)
+
+! ... (mg_instance, parent_box_id, child_offset, fine_box_size, variable_index are set up)
+! fine_box_size = mg_instance%box_size_lvl(mg_instance%boxes(parent_box_id)%lvl + 1)
+! allocate(interpolated_data_for_child(fine_box_size)) ! Assuming 1D for simplicity
+
+! call mg_prolong_sparse(mg_instance, parent_box_id, child_offset, &
+!                        fine_box_size, variable_index, interpolated_data_for_child)
+
+! 'interpolated_data_for_child' now holds the data for one fine child.
+! if (allocated(interpolated_data_for_child)) deallocate(interpolated_data_for_child)
+
+```

--- a/docs/src/doc_m_restrict.f90.md
+++ b/docs/src/doc_m_restrict.f90.md
@@ -1,0 +1,111 @@
+# `m_restrict.f90`
+
+## Overview
+
+The `m_restrict` module is a fundamental part of the `m_octree_mg` multigrid library, dedicated to the restriction operation. In multigrid algorithms, restriction is the process of transferring data from a finer grid level to the immediate next coarser grid level. This data typically consists of either the solution itself or, more commonly in Full Approximation Scheme (FAS), the residual of the solution (the difference between the right-hand side and the operator applied to the current solution approximation). This module implements a full-weighting restriction method and manages the necessary MPI communication when data needs to be transferred between processes.
+
+## Key Components
+
+### Modules
+
+- **`m_restrict`:** Contains subroutines for calculating restriction communication buffer sizes, the main restriction drivers, and the core logic for data restriction.
+
+### Functions/Subroutines
+
+- **`mg_restrict_buffer_size(mg, n_send, n_recv, dsize)`:**
+  - **Description:** Calculates the maximum required MPI communication buffer sizes for data exchange during restriction operations. It iterates through the grid levels, determining for each fine level how many data packets (each corresponding to one coarse cell's worth of restricted data) need to be sent from local fine-grid children to their remote coarse-grid parents, and vice-versa for receiving.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure. Buffer needs are stored in `mg%comm_restrict`.
+    - `n_send (integer, intent(out), array)`: Maximum number of items (coarse cells) to be sent by the current process.
+    - `n_recv (integer, intent(out), array)`: Maximum number of items (coarse cells) to be received by the current process.
+    - `dsize (integer, intent(out))`: Size of a single data element being transferred (effectively 1, as it's per coarse cell, which is `(mg%box_size/2)**NDIM` fine cells averaged).
+
+- **`mg_restrict(mg, iv)`:**
+  - **Description:** A high-level convenience routine that performs the restriction operation for a specified variable `iv` across all applicable grid levels. It iterates from the finest level (`mg%highest_lvl`) down to the level immediately above the coarsest (`mg%lowest_lvl+1`), calling `mg_restrict_lvl` for each transition.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `iv (integer, intent(in))`: Index of the variable (e.g., `mg_iphi`, `mg_ires`) to be restricted.
+
+- **`mg_restrict_lvl(mg, iv, lvl)`:**
+  - **Description:** This is the main driver subroutine for restricting the variable `iv` from a fine grid level `lvl` to its coarser parent level `lvl-1`.
+    1.  For levels requiring communication (`lvl >= mg%first_normal_lvl`), it iterates through all locally owned fine grid boxes on `lvl`. If a fine box's parent on level `lvl-1` resides on a different MPI rank, the `restrict_set_buffer` routine is called. This routine computes the restricted value (one coarse cell's worth) from the fine box and packs it into a send buffer destined for the parent's rank.
+    2.  It then calls `sort_and_transfer_buffers` (from `m_communication`) to execute the actual MPI send/receive operations.
+    3.  Finally, it iterates through all locally owned parent boxes on the coarse level `lvl-1`. For each such parent, `restrict_onto` is called to populate its cell data by gathering contributions from all its children (whether local or received via MPI).
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure.
+    - `iv (integer, intent(in))`: Index of the variable on the fine grid (`lvl`) to be restricted. The result is stored in the same variable index `iv` on the coarse grid (`lvl-1`).
+    - `lvl (integer, intent(in))`: The fine grid level from which data is restricted.
+
+### Private Helper Subroutines
+
+- **`restrict_set_buffer(mg, id, iv)`:**
+  - **Description:** Called for a fine grid box `id` (variable `iv`) if its parent `p_id` is on a different MPI rank. This routine computes the single coarse cell value that box `id` contributes to its parent `p_id`. This is done using a full weighting scheme (averaging the $2^{NDIM}$ fine cells within `id` that correspond to that specific coarse cell in `p_id`). This single averaged value is then packed into the send buffer for `p_rank`. The sorting index for the buffer is based on `p_id` and which child `id` is (its index `n` from 1 to `mg_num_children`).
+- **`restrict_onto(mg, id, nc, iv)`:**
+  - **Description:** Called for a coarse grid parent box `id` (on level `lvl-1`) to populate its data for variable `iv`. It iterates through its $2^{NDIM}$ child positions.
+    - If a child `c_id` (on fine level `lvl`) is local (owned by the current MPI process), this routine directly accesses the child's data and performs the full weighting average of the $2^{NDIM}$ fine cells within `c_id` that correspond to the current coarse cell being computed in `id`.
+    - If a child `c_id` is remote, the (already averaged by the sender via `restrict_set_buffer`) value for the corresponding coarse cell is unpacked from the MPI receive buffer.
+    The routine correctly places these computed or received values into the appropriate cells of the coarse parent box `id`.
+
+## Important Variables/Constants
+
+- **Restriction Method:** The module implements **full weighting restriction**. In this method, the value of a coarse cell is the average of the values of all the $2^{NDIM}$ fine cells that it covers. For example, in 3D, this is `0.125 * sum(8 fine cell values)`.
+- **Data Size (`dsize`):** In `mg_restrict_buffer_size`, `dsize` is set to `(mg%box_size/2)**NDIM`. This represents the number of cells in a *coarse* box if restriction were done box-by-box. However, the communication itself sends individual coarse cell values when parents are remote, so the effective `dsize` for `sort_and_transfer_buffers` in `mg_restrict_lvl` is `1` (representing one coarse cell value).
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Essential for `type(mg_t)`, `type(mg_box_t)`, `type(mg_lvl_t)`, the precision kind `dp`, `NDIM`, constants like `mg_num_children`, and utility functions such as `mg_ix_to_ichild` (used for buffer sorting index) and `mg_get_child_offset` (used to map child data to parent cells).
+  - **`m_communication`:** Relies on the `sort_and_transfer_buffers` subroutine from this module to perform the actual MPI exchange of restricted data packets.
+- **External Libraries:**
+  - **`cpp_macros.h`:** Used for `DTIMES` (dimension-agnostic array slicing), `KJI_DO`/`CLOSE_DO` (looping macros), and `NDIM`-dependent conditional compilation of the averaging stencils.
+- **Interactions with Other Components:**
+  - **`m_multigrid`:** This is a primary interaction point. The `mg_restrict_lvl` routine is invoked by the `update_coarse` subroutine within the FAS V-cycle and FMG algorithms. In FAS, restriction is used to transfer both the current fine-grid solution approximation (which becomes the old solution on the coarse grid) and the fine-grid residual (which contributes to the coarse-grid right-hand side).
+  - **`m_allocate_storage` (indirectly):** The `mg_restrict_buffer_size` routine is called during the library's setup phase (likely by `m_allocate_storage` or a similar top-level initialization routine that pre-calculates all buffer needs) to determine the maximum buffer sizes required for restriction data exchange.
+
+## Usage Examples
+
+Restriction is mostly an internal operation within the multigrid cycles, orchestrated by routines in `m_multigrid`. Users typically do not call `mg_restrict_lvl` directly.
+
+```fortran
+! Conceptual Example: How restriction is invoked within m_multigrid's update_coarse.
+
+! In m_multigrid, within a routine like update_coarse(mg, fine_lvl):
+! ...
+! ! Assume 'mg' is type(mg_t)
+! ! 'fine_lvl' is the current fine level index from which we are restricting.
+! ! The solution on 'fine_lvl' is in 'mg_iphi'.
+! ! The residual on 'fine_lvl' (f_f - L_f phi_f) has just been computed and is in 'mg_ires'.
+
+! if (fine_lvl > mg%lowest_lvl) then
+!   ! Restrict the current fine-grid solution (mg_iphi on fine_lvl)
+!   ! to the coarse grid (mg_iphi on fine_lvl-1). This will serve as phi_coarse_old.
+!   call mg_restrict_lvl(mg, mg_iphi, fine_lvl)
+!
+!   ! Restrict the fine-grid residual (mg_ires on fine_lvl)
+!   ! to the coarse grid (mg_ires on fine_lvl-1).
+!   call mg_restrict_lvl(mg, mg_ires, fine_lvl)
+!
+!   ! The coarse grid (level 'fine_lvl - 1') now has:
+!   ! - its 'mg_iphi' field populated with the restricted fine-level solution.
+!   ! - its 'mg_ires' field populated with the restricted fine-level residual.
+!   ! These are then used to form the FAS coarse grid equation:
+!   ! L_c(phi_c) = L_c(restrict(phi_f)) + restrict(f_f - L_f(phi_f))
+! ...
+! end if
+
+! Direct call (less common for end-users):
+use m_data_structures
+use m_restrict
+
+type(mg_t) :: mg_state
+integer    :: level_to_restrict_from, variable_index
+
+! ... (mg_state is fully initialized, data exists on level_to_restrict_from for variable_index)
+! level_to_restrict_from = mg_state%highest_lvl
+! variable_index = mg_iphi
+
+! if (level_to_restrict_from > mg_state%lowest_lvl) then
+!    call mg_restrict_lvl(mg_state, variable_index, level_to_restrict_from)
+! end if
+! Now, variable_index on level (level_to_restrict_from - 1) contains restricted data.
+```

--- a/docs/src/doc_m_vhelmholtz.f90.md
+++ b/docs/src/doc_m_vhelmholtz.f90.md
@@ -1,0 +1,124 @@
+# `m_vhelmholtz.f90`
+
+## Overview
+
+The `m_vhelmholtz` module implements procedures for the solution of a variable-coefficient Helmholtz equation using the `m_octree_mg` multigrid library. The general form of the equation solved is $\nabla \cdot (D(\mathbf{x}) \nabla \phi) - \lambda \phi = f$. In this equation:
+- $\phi$ is the unknown field to be solved.
+- $D(\mathbf{x})$ is a spatially varying isotropic diffusion coefficient. This coefficient must be provided by the user and stored as a cell-centered quantity in the `mg_iveps` variable component of the `mg%boxes(:)%cc` data arrays for each grid box.
+- $\lambda$ is a scalar constant (non-negative).
+- $f$ is the source term.
+
+This module provides the discretized form of this operator and a corresponding Gauss-Seidel based smoother, which are then utilized by the main multigrid solver routines. The discretization uses harmonic averaging for the diffusion coefficient $D(\mathbf{x})$ at cell faces.
+
+## Key Components
+
+### Modules
+
+- **`m_vhelmholtz`:** Encapsulates the variable-coefficient Helmholtz operator, smoother, and configuration routines.
+
+### Public Module Variable
+
+- **`vhelmholtz_lambda (real(dp), public, protected)`:**
+  - **Description:** Stores the global constant value for the $\lambda$ term in the Helmholtz equation. This value must be non-negative ($\ge 0$). It is initialized to `0.0_dp`. If $\lambda = 0$, the equation becomes a variable-coefficient Poisson equation $\nabla \cdot (D(\mathbf{x}) \nabla \phi) = f$.
+  - **Accessed by:** `vhelmholtz_set_lambda` (to set) and the private `box_gs_vhelmh` and `box_vhelmh` routines (to use).
+
+### Functions/Subroutines
+
+- **`vhelmholtz_set_methods(mg)`:**
+  - **Description:** Configures the provided multigrid structure (`mg` of type `mg_t`) to use the variable-coefficient Helmholtz operator and smoother defined in this module.
+    - It assigns the internal `box_vhelmh` subroutine to `mg%box_op` (operator application) and `box_gs_vhelmh` to `mg%box_smoother`.
+    - It checks if `mg%n_extra_vars` is at least 1 (required for storing the diffusion coefficient $D(\mathbf{x})$ in `mg_iveps`). If `mg` is already allocated and `n_extra_vars` is 0, it stops with an error. Otherwise, it ensures `n_extra_vars` is at least 1.
+    - It sets `mg%subtract_mean` to `.false.`.
+    - Crucially, it sets the boundary condition type for the `mg_iveps` variable to `mg_bc_neumann` with a value of `0.0_dp`. This ensures that the diffusion coefficient $D$ can be correctly accessed in ghost cells when applying stencils near box boundaries, typically by copying the edge value into the ghost cell.
+    - Currently supports `mg_cartesian` geometry and smoother types `mg_smoother_gs` or `mg_smoother_gsrb`.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure to be configured.
+
+- **`vhelmholtz_set_lambda(lambda)`:**
+  - **Description:** Sets the value of the module-level variable `vhelmholtz_lambda`. It enforces that `lambda` must be non-negative; an error is raised if `lambda < 0`.
+  - **Arguments:**
+    - `lambda (real(dp), intent(in))`: The value for the constant $\lambda$.
+
+### Private Module Procedures (Core Operations)
+
+- **`box_gs_vhelmh(mg, id, nc, redblack_cntr)`:**
+  - **Description:** Performs a Gauss-Seidel relaxation sweep (standard or Red-Black, based on `mg%smoother_type`) for the variable-coefficient Helmholtz equation on the data within a single box `id`. It updates `mg_iphi` using values from neighboring cells, the source term `mg_irhs`, the spatially varying diffusion coefficient $D$ (from `mg_iveps`), and `vhelmholtz_lambda`. The diffusion coefficient $D$ at cell faces is computed using harmonic averaging: $D_{face} = 2 D_0 D_{neighbor} / (D_0 + D_{neighbor})$, where $D_0$ is $D$ at the current cell and $D_{neighbor}$ is $D$ at the neighboring cell.
+  - **Arguments:** (Standard signature for `mg_box_gsrb`)
+
+- **`box_vhelmh(mg, id, nc, i_out)`:**
+  - **Description:** Applies the discretized variable-coefficient Helmholtz operator ($\nabla \cdot (D \nabla \phi) - \lambda \phi$) to the solution variable `phi` (in `mg_iphi`) within box `id`. The result is stored in `cc(..., i_out)`. Like the smoother, it uses harmonic averaging for the diffusion coefficient $D$ at cell faces.
+  - **Arguments:** (Standard signature for `mg_box_op`)
+
+## Important Variables/Constants
+
+- **`vhelmholtz_lambda (real(dp))`**: The constant scalar value $\lambda$.
+- **Diffusion Coefficient $D(\mathbf{x})$ Storage:** The spatially varying diffusion coefficient is expected to be stored by the user in the `mg_iveps` component of the `mg%boxes(id)%cc` array for every cell in every box.
+- **Harmonic Averaging:** The discretization of $\nabla \cdot (D \nabla \phi)$ uses harmonic averaging for $D$ at cell interfaces. For a face between cell $i$ and cell $i+1$, the effective $D_{face}$ is $2 D_i D_{i+1} / (D_i + D_{i+1})$. This is important for maintaining accuracy when $D$ varies sharply.
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Essential for `type(mg_t)`, `type(mg_box_t)`, `dp`, `NDIM`, variable indices (`mg_iphi`, `mg_irhs`, `mg_iveps`), geometry types (`mg_cartesian`), smoother types (`mg_smoother_gs`, `mg_smoother_gsrb`), and boundary condition types (`mg_bc_neumann`).
+- **External Libraries:**
+  - **`cpp_macros.h`:** Used for conditional compilation (`#if NDIM == ...`) to provide dimension-specific implementations of stencil operations.
+- **Interactions with Other Components:**
+  - **`m_multigrid`:** This is the primary consumer module. `vhelmholtz_set_methods` is called (usually via `mg_set_methods` in `m_multigrid` when `mg%operator_type` is `mg_vhelmholtz`) to register `box_vhelmh` as `mg%box_op` and `box_gs_vhelmh` as `mg%box_smoother`. The generic multigrid cycling routines then invoke these.
+  - **`m_ghost_cells`:** Before the multigrid routines call the operator or smoother, ghost cells for `mg_iphi`, `mg_irhs`, and critically for `mg_iveps` (the variable diffusion coefficient) must be filled. `vhelmholtz_set_methods` configures Neumann boundary conditions for `mg_iveps` to facilitate this.
+  - **Application Modules (e.g., `m_diffusion`):** The `diffusion_solve_vcoeff` routine in `m_diffusion` uses `m_vhelmholtz` to solve time-dependent diffusion equations where the diffusion coefficient varies spatially. The application code is responsible for populating `mg_iveps` at all grid levels.
+
+## Usage Examples
+
+```fortran
+! Conceptual Example: Setting up to solve a variable-coefficient Helmholtz problem.
+
+use m_data_structures
+use m_vhelmholtz
+use m_multigrid      ! For the generic mg_set_methods
+
+implicit none
+
+type(mg_t) :: my_problem_config
+real(dp)   :: const_lambda_term
+integer    :: lvl, i, id, nc
+integer    :: iveps_idx ! Should be mg_iveps
+
+! 1. Initialize 'my_problem_config' (grid, MPI, etc.)
+!    call comprehensive_mg_initialization(my_problem_config) ! Placeholder
+my_problem_config%geometry_type = mg_cartesian
+my_problem_config%smoother_type = mg_smoother_gsrb
+
+! 2. Ensure space for the variable coefficient D(x) is requested BEFORE allocation.
+!    mg_iveps is typically 5.
+iveps_idx = mg_iveps
+my_problem_config%n_extra_vars = max(my_problem_config%n_extra_vars, iveps_idx - mg_num_vars + 1)
+!    ... (call mg_allocate_storage(my_problem_config) ) ...
+
+! 3. Populate the diffusion coefficient D(x) and the source term f.
+!    This must be done for all relevant boxes and levels.
+do lvl = my_problem_config%lowest_lvl, my_problem_config%highest_lvl
+  nc = my_problem_config%box_size_lvl(lvl)
+  do i = 1, size(my_problem_config%lvls(lvl)%my_ids)
+    id = my_problem_config%lvls(lvl)%my_ids(i)
+    ! Example: Set D(x) = 1.0 + coordinate_x, and f = some_function
+    ! my_problem_config%boxes(id)%cc(..., iveps_idx) = 1.0_dp + my_problem_config%boxes(id)%r_min(1) + ...
+    ! my_problem_config%boxes(id)%cc(..., mg_irhs) = ...
+  end do
+end do
+
+! 4. Specify that the problem is a variable-coefficient Helmholtz type.
+my_problem_config%operator_type = mg_vhelmholtz
+
+! 5. Set the constant lambda for the Helmholtz term.
+const_lambda_term = 1.5_dp
+call vhelmholtz_set_lambda(const_lambda_term)
+
+! 6. Associate the vhelmholtz operator and smoother with the mg_t object.
+!    This will also set up Neumann BCs for mg_iveps.
+call mg_set_methods(my_problem_config)
+
+! Now, 'my_problem_config' is configured. When multigrid routines
+! (e.g., mg_fas_fmg) are called, they will use 'box_vhelmh' and 'box_gs_vhelmh'.
+! Crucially, ghost cells for mg_iphi, mg_irhs, AND mg_iveps must be filled
+! during the multigrid cycles (call mg_fill_ghost_cells_lvl(..., mg_iveps)).
+! The Neumann BC setup in vhelmholtz_set_methods helps with mg_iveps ghost cells.
+```

--- a/docs/src/doc_m_vlaplacian.f90.md
+++ b/docs/src/doc_m_vlaplacian.f90.md
@@ -1,0 +1,111 @@
+# `m_vlaplacian.f90`
+
+## Overview
+
+The `m_vlaplacian` module in the `m_octree_mg` library is designed to handle PDEs involving a variable-coefficient Laplacian operator. Specifically, it addresses equations of the form $\nabla \cdot (D(\mathbf{x}) \nabla \phi) = f$, where $D(\mathbf{x})$ is a spatially varying isotropic coefficient (e.g., diffusion coefficient, thermal conductivity, electrical permittivity) and $f$ is a source term. The coefficient $D(\mathbf{x})$ must be provided by the user and is expected to be stored as a cell-centered quantity in the `mg_iveps` variable component of the `mg%boxes(:)%cc` data arrays for each grid box. This module provides the discretized form of the $\nabla \cdot (D(\mathbf{x}) \nabla \cdot)$ operator and a corresponding Gauss-Seidel based smoother, which are essential for the multigrid solution process. The discretization uses harmonic averaging for the coefficient $D(\mathbf{x})$ at cell faces to ensure accuracy, especially when $D$ varies significantly between cells.
+
+This module is structurally very similar to `m_vhelmholtz`, essentially representing the case where the Helmholtz parameter $\lambda=0$.
+
+## Key Components
+
+### Modules
+
+- **`m_vlaplacian`:** Encapsulates the variable-coefficient Laplacian operator, smoother, and configuration routines.
+
+### Functions/Subroutines
+
+- **`vlaplacian_set_methods(mg)`:**
+  - **Description:** Configures the provided multigrid structure (`mg` of type `mg_t`) to use the variable-coefficient Laplacian operator and smoother defined in this module.
+    - It assigns the internal `box_vlpl` subroutine to `mg%box_op` (operator application) and `box_gs_vlpl` to `mg%box_smoother`.
+    - It verifies that `mg%n_extra_vars` is at least 1 (necessary for storing the coefficient $D(\mathbf{x})$ in `mg_iveps`). If `mg` is already allocated and `n_extra_vars` is 0, it issues an error. Otherwise, it ensures `n_extra_vars` is at least 1.
+    - It sets `mg%subtract_mean` to `.false.` (mean subtraction is typically for pure Neumann problems with constant coefficients, which is not the primary target here, though specific boundary conditions might still require it at a higher level).
+    - It establishes Neumann zero boundary conditions for the `mg_iveps` variable. This is crucial for ensuring that the coefficient $D$ can be correctly accessed in ghost cells during stencil operations near box boundaries.
+    - Currently, it supports `mg_cartesian` geometry and smoother types `mg_smoother_gs` (Gauss-Seidel) or `mg_smoother_gsrb` (Gauss-Seidel Red-Black).
+    - A commented-out line `! mg%box_prolong => vlpl_prolong` suggests that a custom prolongation method tailored for variable coefficients (`vlpl_prolong`, also commented out in the file) was considered but is not currently active. The default prolongation method from `m_multigrid` would be used.
+  - **Arguments:**
+    - `mg (type(mg_t), intent(inout))`: The multigrid data structure to be configured.
+
+### Private Module Procedures (Core Operations)
+
+- **`box_gs_vlpl(mg, id, nc, redblack_cntr)`:**
+  - **Description:** This subroutine performs a Gauss-Seidel relaxation sweep (either standard or Red-Black, depending on `mg%smoother_type`) for the variable-coefficient Poisson equation $\nabla \cdot (D \nabla \phi) = f$ on the data within a single box `id`. It updates the solution variable (`mg_iphi`) using values from neighboring cells, the source term (`mg_irhs`), and the spatially varying coefficient $D$ (from `mg_iveps`). The coefficient $D$ at cell faces is computed using harmonic averaging: $D_{face} = 2 D_0 D_{neighbor} / (D_0 + D_{neighbor})$.
+  - **Arguments:** (Standard signature for `mg_box_gsrb`)
+
+- **`box_vlpl(mg, id, nc, i_out)`:**
+  - **Description:** This subroutine applies the discretized variable-coefficient Laplacian operator $\nabla \cdot (D(\mathbf{x}) \nabla \phi)$ to the solution variable `phi` (stored at index `mg_iphi`) within box `id`. The result of the operation is stored in the `i_out` component of the box's `cc` array. It also uses harmonic averaging for the coefficient $D$ at cell faces.
+  - **Arguments:** (Standard signature for `mg_box_op`)
+
+### Commented-Out Code
+- **`vlpl_prolong`:** The file contains a commented-out subroutine `vlpl_prolong`. This indicates that a specialized prolongation operator, potentially designed to be more accurate for variable coefficients by taking $D(\mathbf{x})$ into account during interpolation, was developed or considered. However, it is not currently part of the active code.
+
+## Important Variables/Constants
+
+- **Coefficient $D(\mathbf{x})$ Storage:** The spatially varying coefficient $D$ is not a module-level variable but is expected to be provided by the user within the `mg%boxes(id)%cc(..., mg_iveps)` array for each cell.
+- **Harmonic Averaging:** The discretization of the $\nabla \cdot (D \nabla \phi)$ term critically relies on harmonic averaging of $D$ values from adjacent cells to determine the effective coefficient at cell interfaces. This is a standard practice to maintain physical realism (e.g., flux continuity) when coefficients change abruptly.
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - **`m_data_structures`:** Essential for `type(mg_t)`, `type(mg_box_t)`, `dp`, `NDIM`, variable indices (`mg_iphi`, `mg_irhs`, `mg_iveps`), geometry types (`mg_cartesian`), smoother types (`mg_smoother_gs`, `mg_smoother_gsrb`), and boundary condition type constants (`mg_bc_neumann`).
+- **External Libraries:**
+  - **`cpp_macros.h`:** Used for conditional compilation based on `NDIM` to provide dimension-specific implementations of the stencil operations.
+- **Interactions with Other Components:**
+  - **`m_multigrid`:** This is the primary consumer. `vlaplacian_set_methods` is called (typically via `mg_set_methods` in `m_multigrid` when `mg%operator_type` is `mg_vlaplacian`) to register `box_vlpl` as `mg%box_op` and `box_gs_vlpl` as `mg%box_smoother`. The generic multigrid cycling routines then invoke these procedures.
+  - **`m_ghost_cells`:** Before the operator or smoother can be applied, ghost cells for the solution (`mg_iphi`), the right-hand side (`mg_irhs` for the smoother), and importantly, the variable coefficient (`mg_iveps`) must be correctly filled. The `vlaplacian_set_methods` routine configures Neumann boundary conditions for `mg_iveps` to assist in this.
+  - **Application Code:** Users wishing to solve equations like $\nabla \cdot (D(\mathbf{x}) \nabla \phi) = f$ would set `mg%operator_type = mg_vlaplacian`, populate `mg_iveps` with the coefficient $D(\mathbf{x})$ at all relevant grid levels, and then use the standard multigrid solvers.
+
+## Usage Examples
+
+```fortran
+! Conceptual Example: Setting up the multigrid solver for a variable-coefficient
+! Poisson-like problem.
+
+use m_data_structures
+use m_vlaplacian
+use m_multigrid      ! For the generic mg_set_methods
+
+implicit none
+
+type(mg_t) :: my_problem_config
+integer    :: lvl, i, box_idx, num_cells
+integer    :: D_coeff_idx ! Should be mg_iveps
+
+! 1. Initialize 'my_problem_config' (grid, MPI setup, etc.)
+!    call comprehensive_mg_initialization(my_problem_config) ! Placeholder
+my_problem_config%geometry_type = mg_cartesian
+my_problem_config%smoother_type = mg_smoother_gsrb
+
+! 2. Specify the need for an extra variable to store D(x).
+!    The index mg_iveps (usually 5) is used for this.
+D_coeff_idx = mg_iveps
+my_problem_config%n_extra_vars = max(my_problem_config%n_extra_vars, D_coeff_idx - mg_num_vars + 1)
+
+! 3. After tree building and load balancing, allocate storage.
+!    call mg_allocate_storage(my_problem_config) ! This will now include space for D_coeff_idx.
+
+! 4. Populate the variable coefficient D(x) and the source term f.
+!    This must be done for all locally owned boxes on all relevant levels.
+do lvl = my_problem_config%lowest_lvl, my_problem_config%highest_lvl
+  num_cells = my_problem_config%box_size_lvl(lvl)
+  do i = 1, size(my_problem_config%lvls(lvl)%my_ids)
+    box_idx = my_problem_config%lvls(lvl)%my_ids(i)
+    ! Example: Set D(x) based on spatial location, and f to some function
+    ! my_problem_config%boxes(box_idx)%cc(..., D_coeff_idx) = calculate_D_at_cell(...)
+    ! my_problem_config%boxes(box_idx)%cc(..., mg_irhs)    = calculate_f_at_cell(...)
+  end do
+end do
+
+! 5. Set the operator type to indicate a variable-coefficient Laplacian problem.
+my_problem_config%operator_type = mg_vlaplacian
+
+! 6. Associate the vlaplacian operator and smoother with the mg_t object.
+!    This call will also configure Neumann BCs for D_coeff_idx (mg_iveps).
+call mg_set_methods(my_problem_config)
+
+! Now, 'my_problem_config' is ready. When multigrid routines like mg_fas_fmg
+! are invoked, they will use 'box_vlpl' for operator applications and
+! 'box_gs_vlpl' for smoothing.
+! It's crucial that ghost cells for mg_iphi, mg_irhs, AND D_coeff_idx (mg_iveps)
+! are correctly filled during the multigrid cycles. The Neumann BC setup for
+! mg_iveps by vlaplacian_set_methods aids in this process for the coefficient.
+```

--- a/documentation_template.md
+++ b/documentation_template.md
@@ -1,0 +1,55 @@
+# [File Name]
+
+## Overview
+
+[Brief description of what the code file does and its role within the larger project.]
+
+## Key Components
+
+### Functions/Subroutines
+
+- **[Function/Subroutine Name 1]:** [Short description of what it does.]
+- **[Function/Subroutine Name 2]:** [Short description of what it does.]
+  - **Arguments:**
+    - `[Argument 1 Name] ([Type], [Intent]):` [Description of the argument.]
+    - `[Argument 2 Name] ([Type], [Intent]):` [Description of the argument.]
+  - **Returns:** `[Return Value Name] ([Type]):` [Description of the return value, if applicable.]
+- ...
+
+### Modules
+
+- **[Module Name 1]:** [Short description of what it does and what it contains.]
+- ...
+
+### Classes (if applicable)
+
+- **[Class Name 1]:** [Short description of the class.]
+  - **Properties:**
+    - `[Property 1 Name] ([Type]):` [Description.]
+  - **Methods:**
+    - `[Method 1 Name]():` [Description.]
+- ...
+
+## Important Variables/Constants
+
+- **[Variable/Constant Name 1] (`[Type]`):** [Description of its purpose and how it affects behavior.]
+- **[Variable/Constant Name 2] (`[Type]`):** [Description of its purpose and how it affects behavior.]
+- ...
+
+## Usage Examples
+
+[Optional: Code snippets or examples demonstrating how to use the functions, classes, or modules in this file. This section can be populated later if examples are not immediately obvious.]
+
+```fortran
+! Example code here
+```
+
+## Dependencies and Interactions
+
+- **Internal Dependencies:**
+  - `[Module/File Name 1]:` [How this file depends on it (e.g., "Uses module X for data structures").]
+  - `[Module/File Name 2]:` [How this file depends on it.]
+- **External Libraries:**
+  - `[Library Name 1]:` [Reason for dependency (e.g., "Used for MPI communication").]
+- **Interactions with Other Components:**
+  - [Describes how this file/module interacts with other parts of the system (e.g., "Called by Y to perform Z").]


### PR DESCRIPTION
This commit introduces extensive Markdown documentation for the octree-mg library. The goal was to generate developer-focused documentation for each significant code file, detailing its overview, key components, variables, usage, and dependencies.

Key actions taken:
1.  I created a standardized Markdown template (`documentation_template.md`) to ensure consistency across all documentation files.
2.  I generated documentation for all 18 Fortran modules in the main `src/` directory. These files are located in `docs/src/` and cover the core data structures, multigrid algorithms, PDE operators (Laplacian, Helmholtz, Diffusion, and their variable-coefficient versions), grid management (build tree, load balance, allocation), and communication primitives (ghost cells, restrict, prolong).
3.  I generated documentation for key components of the `poisson_3d_fft/` directory. This includes:
    -   `poisson_solver.f90`: The main module providing the FFT-based
        Poisson solver.
    -   `fft3d.f90`: Low-level FFT routines.
    -   `build_kernel.f90`: Routines for constructing the Poisson kernel.
    -   `psolver_main.f90`: The main `PSolver` driver routine.
    These files are located in `docs/poisson_3d_fft/`.
4.  I generated documentation for the `single_module/` directory. This includes:
    -   An overview document (`docs/single_module/doc_single_module_overview.md`)
        explaining the purpose and usage of the single-file modules.
    -   Specific documentation for `single_module/m_free_space.f90`
        (`docs/single_module/doc_m_free_space_single_module.f90.md`),
        which provides a free-space Poisson solver for use with the
        3D single-module version of the main library.
5.  I performed a review of the generated files to ensure structural
    consistency and completeness.

This documentation should significantly aid developers in understanding, maintaining, and extending the octree-mg codebase.